### PR TITLE
Build fix for #151

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ before_script:
 script:
   - >
     awesome_bot -f README.md --allow-ssl --allow-redirect --allow-dupe
-    --white-list www.linkedin.com,www.hostelworldgroup.com,www.olxgroup.com,www.prozis.com
+    --white-list www.linkedin.com,www.hostelworldgroup.com,www.olxgroup.com,www.prozis.com,www.glintt.com

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Are you seeking for a job? Click :rocket: to check the company's careers page.
 | [Redlight Software](https://weareredlight.com) | Web and mobile development studio focused on products. | `Coimbra` `Lisboa` |
 | [Runtime Revolution](https://www.runtime-revolution.com/) [:rocket:](https://www.runtime-revolution.com/careers) | Web and mobile product development. | `Lisboa` |
 | [Significa](https://www.significa.pt) [:rocket:](https://www.significa.pt/careers/) | Design and Front-End Web development. | `Porto` |
-| [Subvisual](https://subvisual.co/) [:rocket:](https://subvisual.co/company/join-us/) | Web development and design firm. | `Braga` |
+| [Subvisual](https://subvisual.com/) | Web development and design firm. | `Braga` |
 | [Thing Pink](http://www.thing-pink.pt) [:rocket:](http://www.thing-pink.pt/joinus) | Digital Agency with focus on Web, Mobile and IoT. | `Lisboa` `Porto` |
 | [Vizzuality](https://www.vizzuality.com) [:rocket:](https://vizzuality.bamboohr.com/jobs/) | Digital Agency focused in having a positive impact in the world. | `Porto` `remote` |
 | [Waterdog](https://waterdog.mobi/) | Web and Mobile development. | `Porto` |

--- a/README.md
+++ b/README.md
@@ -121,7 +121,6 @@ Are you seeking for a job? Click :rocket: to check the company's careers page.
 | [Bliss Applications](https://www.blissapplications.com/) [:rocket:](https://www.blissapplications.com/careers) | UX/UI & software-driven company. | `Lisboa` `Porto` |
 | [Coletiv](https://www.coletiv.com) [:rocket:](https://coletiv.com/#jobs) | Mobile and backend development. | `Porto` |
 | [Dengun](https://www.dengun.com/en/) [:rocket:](https://www.dengun.com/en/jobs/) | Web, Mobile development and digital marketing. | `Faro` |
-| [Foreteller](https://www.weareforeteller.com/) [:rocket:](https://www.weareforeteller.com/foreteller-about) | Design-led partner for great results. | `Lisboa` |
 | [Imaginary Cloud](https://www.imaginarycloud.com) [:rocket:](https://www.imaginarycloud.com/careers) | Web, mobile, development and design services. | `Lisboa` |
 | [Load](http://load.digital) [:rocket:](https://consultancy.load.digital/carreiras) | Design Thinking, Web, Mobile, IoT, New Tech (VR, AI, Blockchain) | `Aveiro` `Remote` |
 | [Pixelmatters](http://pixelmatters.com) [:rocket:](http://pixelmatters.com/jobs/) | Digital product design and development company. | `Porto` |


### PR DESCRIPTION
Fixing issues reported on #151 plus another new one.

* Whitelisted Glintt
* Removed Foreteller because site is down for 2 weeks and no other signs of life found
* Updated Subvisual site which seems to have migrated from .co to .com (according to their twitter page)
  * Their offers page seems to have disappear so it was also removed