### PR TITLE
Add Teamlyzer url to companies

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,142 +36,142 @@ Are you seeking for a job? Click :rocket: to check the company's careers page.
 
 | Company | Description | Locations |
 | :------ | :---------- | :-------- |
-| [AddVolt](https://addvolt.com/) [:rocket:](https://www.addvolt.com/en/#Contacts) | AddVolt's platform reduces CO2 in the heavy transportation sector. |  `Porto` |
-| [Critical TechWorks](https://www.criticaltechworks.com/) [:rocket:](https://www.criticaltechworks.com/#openroll) | Developing next generation software systems for BMW. | `Lisboa` `Porto` |
-| [DTB Tech & Data Hub](https://techhublisbon.io/) [:rocket:](https://techhublisbon.softgarden.io/en/vacancies) | Daimler Trucks and Buses IoT data into intelligent global services. | `Lisboa` |
-| [Mercedes-Benz.io](https://www.mercedes-benz.io) [:rocket:](https://www.mercedes-benz.io/jobs) | Shaping the digital future of Mercedes-Benz. | `Lisboa` |
-| [Stratio Automotive](https://stratioautomotive.com) [:rocket:](https://stratio.workable.com) | Vehicle data into predictive intelligence. | `Coimbra` |
-| [Volkswagen Digital Solutions](http://www.vwds.pt/) [:rocket:](https://www.linkedin.com/company/volkswagen-digital-solutions/jobs/) | Creating the digital ecosystem for the brands of the Volkswagen Group. | `Lisboa` |
+| [AddVolt](https://addvolt.com/) [:rocket:](https://www.addvolt.com/en/#Contacts) [:speech_balloon:](https://pt.teamlyzer.com/companies/addvolt) | AddVolt's platform reduces CO2 in the heavy transportation sector. |  `Porto` |
+| [Critical TechWorks](https://www.criticaltechworks.com/) [:rocket:](https://www.criticaltechworks.com/#openroll) [:speech_balloon:](https://pt.teamlyzer.com/companies/critical-techworks) | Developing next generation software systems for BMW. | `Lisboa` `Porto` |
+| [DTB Tech & Data Hub](https://techhublisbon.io/) [:rocket:](https://techhublisbon.softgarden.io/en/vacancies) [:speech_balloon:](https://pt.teamlyzer.com/companies/dtb-tech-data-hub) | Daimler Trucks and Buses IoT data into intelligent global services. | `Lisboa` |
+| [Mercedes-Benz.io](https://www.mercedes-benz.io) [:rocket:](https://www.mercedes-benz.io/jobs) [:speech_balloon:](https://pt.teamlyzer.com/companies/mercedes-benz-io) | Shaping the digital future of Mercedes-Benz. | `Lisboa` |
+| [Stratio Automotive](https://stratioautomotive.com) [:rocket:](https://stratio.workable.com) [:speech_balloon:](https://pt.teamlyzer.com/companies/stratio) | Vehicle data into predictive intelligence. | `Coimbra` |
+| [Volkswagen Digital Solutions](http://www.vwds.pt/) [:rocket:](https://www.linkedin.com/company/volkswagen-digital-solutions/jobs/) [:speech_balloon:](https://pt.teamlyzer.com/companies/volkswagen-group-services) | Creating the digital ecosystem for the brands of the Volkswagen Group. | `Lisboa` |
 
 
 ## Consultancy :man_office_worker: Broad :dizzy:
 
 | Company | Description | Locations |
 | :------ | :---------- | :-------- |
-| [25Friday](https://25friday.com) [:rocket:](https://25friday.homerun.co/) | Digital product management focussed on growing tech companies. | `Aveiro` `Porto` |
-| [Accenture](https://www.accenture.com/pt-pt) [:rocket:](https://www.accenture.com/pt-pt/careers) | Software Development, Cyber Security. | `Lisboa` `Porto` <br> `Remote`|
-| [AddCode](https://addcode-io.breezy.hr) [:rocket:](https://addcode-io.breezy.hr/#positions) | Software engineering. | `Porto` |
-| [Adentis](http://www.adentis.pt/) [:rocket:](http://www.adentis.pt/trabalhar-na-adentis/) | Outsourcing, customized solutions and R&D. | `Lisboa` |
-| [Altran](https://www.altran.com/pt/pt-pt/) [:rocket:](https://www.altran.com/pt/pt-pt/carreiras/) | Engineering and R&D services. | `Fundão` `Lisboa` <br> `Porto` |
-| [Armis](http://www.armisgroup.com/) [:rocket:](http://www.armisgroup.com/ofertas-de-trabalho/) | Technology development and consultancy. | `Lisboa` `Porto` |
-| [Bool Software](https://www.bool.pt/) | Consultancy company specialized in OutSystems. | `Lisboa` |
-| [Caixa Mágica](https://caixamagica.pt/) [:rocket:](https://caixamagica.pt/pt/job-opportunities) | Open Source development. | `Lisboa` |
-| [CGI](https://www.cgi.com/portugal/pt-pt) [:rocket:](https://www.cgi.com/portugal/pt-pt/portugal/careers) | Experience the commitment. | `Lisboa` `Porto` |
-| [darwinLabs](https://www.darwin-labs.com/) [:rocket:](https://www.darwin-labs.com/latest-jobs/) | Building Software that matters. | `Lisboa` `Remote` |
-| [Deloitte](https://www2.deloitte.com/pt/pt.html) [:rocket:](https://yourfuture.deloitte.pt/candidaturas/) | Global consulting company. | `Leiria` `Lisboa` <br> `Porto` `Viseu` |
-| [DevScope](http://devscope.net/) [:rocket:](http://devscope.net/AboutUs/Joinus.aspx) | Technology development, consultancy and product development. | `Porto` `Viseu` |
-| [Equal Experts](https://www.equalexperts.com) [:rocket:](https://www.equalexperts.com/contact-us/lisbon/) | Making software. Better. | `Lisboa` `Remote` |
-| [Findmore](https://findmore.pt/) [:rocket:](https://findmore.pt/careers) | Nearshoring, software development, UX/UI Design and PMO. | `Lisboa` `Porto` <br> `Viseu` |
-| [Growin](https://www.growin.com) [:rocket:](https://www.growin.com/careers/) | Software development and system analysis consultancy. | `Coimbra` `Lisboa` <br> `Porto` |
-| [JAVALI](https://www.javali.pt) | Web, Mobile and custom development. Mostly focused on Drupal. | `Caparica` `Lisboa` |
+| [25Friday](https://25friday.com) [:rocket:](https://25friday.homerun.co/) [:speech_balloon:](https://pt.teamlyzer.com/companies/25friday) | Digital product management focussed on growing tech companies. | `Aveiro` `Porto` |
+| [Accenture](https://www.accenture.com/pt-pt) [:rocket:](https://www.accenture.com/pt-pt/careers) [:speech_balloon:](https://pt.teamlyzer.com/companies/accenture-portugal) | Software Development, Cyber Security. | `Lisboa` `Porto` <br> `Remote`|
+| [AddCode](https://addcode-io.breezy.hr) [:rocket:](https://addcode-io.breezy.hr/#positions) [:speech_balloon:](https://pt.teamlyzer.com/companies/addcode-io) | Software engineering. | `Porto` |
+| [Adentis](http://www.adentis.pt/) [:rocket:](http://www.adentis.pt/trabalhar-na-adentis/) [:speech_balloon:](https://pt.teamlyzer.com/companies/adentis-portugal) | Outsourcing, customized solutions and R&D. | `Lisboa` |
+| [Altran](https://www.altran.com/pt/pt-pt/) [:rocket:](https://www.altran.com/pt/pt-pt/carreiras/) [:speech_balloon:](https://pt.teamlyzer.com/companies/altran-portugal) | Engineering and R&D services. | `Fundão` `Lisboa` <br> `Porto` |
+| [Armis](http://www.armisgroup.com/) [:rocket:](http://www.armisgroup.com/ofertas-de-trabalho/) [:speech_balloon:](https://pt.teamlyzer.com/companies/armis) | Technology development and consultancy. | `Lisboa` `Porto` |
+| [Bool Software](https://www.bool.pt/) [:speech_balloon:](https://pt.teamlyzer.com/companies/bool-software) | Consultancy company specialized in OutSystems. | `Lisboa` |
+| [Caixa Mágica](https://caixamagica.pt/) [:rocket:](https://caixamagica.pt/pt/job-opportunities) [:speech_balloon:](https://pt.teamlyzer.com/companies/caixa-magica) | Open Source development. | `Lisboa` |
+| [CGI](https://www.cgi.com/portugal/pt-pt) [:rocket:](https://www.cgi.com/portugal/pt-pt/portugal/careers) [:speech_balloon:](https://pt.teamlyzer.com/companies/cgi-ti-portugal) | Experience the commitment. | `Lisboa` `Porto` |
+| [darwinLabs](https://www.darwin-labs.com/) [:rocket:](https://www.darwin-labs.com/latest-jobs/) [:speech_balloon:](https://pt.teamlyzer.com/companies/darwin-labs) | Building Software that matters. | `Lisboa` `Remote` |
+| [Deloitte](https://www2.deloitte.com/pt/pt.html) [:rocket:](https://yourfuture.deloitte.pt/candidaturas/) [:speech_balloon:](https://pt.teamlyzer.com/companies/deloitte-consultores) | Global consulting company. | `Leiria` `Lisboa` <br> `Porto` `Viseu` |
+| [DevScope](http://devscope.net/) [:rocket:](http://devscope.net/AboutUs/Joinus.aspx) [:speech_balloon:](https://pt.teamlyzer.com/companies/devscope) | Technology development, consultancy and product development. | `Porto` `Viseu` |
+| [Equal Experts](https://www.equalexperts.com) [:rocket:](https://www.equalexperts.com/contact-us/lisbon/) [:speech_balloon:](https://pt.teamlyzer.com/companies/equal-experts-portugal) | Making software. Better. | `Lisboa` `Remote` |
+| [Findmore](https://findmore.pt/) [:rocket:](https://findmore.pt/careers) [:speech_balloon:](https://pt.teamlyzer.com/companies/findmore-consulting) | Nearshoring, software development, UX/UI Design and PMO. | `Lisboa` `Porto` <br> `Viseu` |
+| [Growin](https://www.growin.com) [:rocket:](https://www.growin.com/careers/) [:speech_balloon:](https://pt.teamlyzer.com/companies/growin) | Software development and system analysis consultancy. | `Coimbra` `Lisboa` <br> `Porto` |
+| [JAVALI](https://www.javali.pt) [:speech_balloon:](https://pt.teamlyzer.com/companies/javali) | Web, Mobile and custom development. Mostly focused on Drupal. | `Caparica` `Lisboa` |
 | [LIS @ IPN](https://www.ipn.pt/laboratorio/LIS) | Technological R&D and innovative multi-disciplinary projects. | `Coimbra` |
-| [LTPLabs](https://www.ltplabs.com/) [:rocket:](https://www.ltplabs.com/careers/) | Boutique analytical-driven management consultancy company. | `Porto` `Lisboa` |
-| [KI labs](https://ki-labs.com/) [:rocket:](https://ki-labs.com/careers/) | Solve complex tech and business challenges for big corporations. | `Lisboa` |
-| [InnoWave](https://innowave.tech/) [:rocket:](https://innowave.tech/careers/) | Global technology and consulting company. | `Coimbra` `Lisboa`|
+| [LTPLabs](https://www.ltplabs.com/) [:rocket:](https://www.ltplabs.com/careers/) [:speech_balloon:](https://pt.teamlyzer.com/companies/ltplabs) | Boutique analytical-driven management consultancy company. | `Porto` `Lisboa` |
+| [KI labs](https://ki-labs.com/) [:rocket:](https://ki-labs.com/careers/) [:speech_balloon:](https://pt.teamlyzer.com/companies/ki-labs) | Solve complex tech and business challenges for big corporations. | `Lisboa` |
+| [InnoWave](https://innowave.tech/) [:rocket:](https://innowave.tech/careers/) [:speech_balloon:](https://pt.teamlyzer.com/companies/innowave-technologies) | Global technology and consulting company. | `Coimbra` `Lisboa`|
 | [IT People](https://itpeople.pt) [:rocket:](https://itpeople.pt/speak-to-us/) | Outsourcing & Nearshore Development. | `Covilhã` `Lisboa` <br> `Porto`|
-| [Mindera](https://mindera.com) [:rocket:](https://mindera.com/#we-are-hiring) | Technology development and consultancy. | `Aveiro` `Coimbra` <br> `Porto` |
-| [Moxy](https://moxy.studio) [:rocket:](https://moxy.studio/team#join-the-team) | Interdisciplinary studio focused on design and development. | `Porto` |
-| [Noesis](https://www.noesis.pt/pt/homepage) [:rocket:](https://www.noesis.pt/pt/junta-te-a-nos/) | Consultancy and enterprise software. | `Lisboa` |
-| [Novabase](http://www.novabase.pt/) [:rocket:](http://www.novabase.pt/en/dp/opportunities) | Simpler & happier. | `Lisboa` |
-| [Opensoft](https://www.opensoft.pt/) [:rocket:](https://www.opensoft.pt/carreiras/) | Making life easier. | `Lisboa` |
-| [Premium Minds](https://www.premium-minds.com/) [:rocket:](https://join.premium-minds.com/) | We build great software for innovative clients. | `Lisboa` |
-| [Present Technologies](https://www.present-technologies.com/) [:rocket:](https://www.present-technologies.com/careers/) | Delivering Quality Software. | `Coimbra` `Porto` <br> `Sertã` |
-| [Syone](https://www.syone.com/) [:rocket:](https://careers.syone.com/) | Outsourcing, nearshore, turnkey projects. | `Alfragide` <br> `Aveiro` `Lisboa` <br>  `Maia` `Matosinhos` <br> `Oeiras` `Porto` |
-| [TMC](https://tmc-employeneurship.com/) [:rocket:](https://www.linkedin.com/company/tmcspain/jobs/) | Agile software development. | `Porto` |
-| [Ubiwhere](https://ubiwhere.com) [:rocket:](https://www.ubiwhere.com/en/careers) | Bleeding Edge Technologies with custom R&D. | `Aveiro` `Coimbra` |
-| [VILT Group](https://www.vilt-group.com/) [:rocket:](https://www.vilt-group.com/joinus) | Consultancy and enterprise software. | `Braga` `Lisboa` |
-| [Xpand IT](https://www.xpand-it.com/pt-pt/) [:rocket:](https://www.xpand-it.com/pt-pt/job-opportunities/) | Global consultancy company. | `Braga` `Lisboa` <br> `Porto` <br> `Viana do Castelo` |
+| [Mindera](https://mindera.com) [:rocket:](https://mindera.com/#we-are-hiring) [:speech_balloon:](https://pt.teamlyzer.com/companies/mindera) | Technology development and consultancy. | `Aveiro` `Coimbra` <br> `Porto` |
+| [Moxy](https://moxy.studio) [:rocket:](https://moxy.studio/team#join-the-team) [:speech_balloon:](https://pt.teamlyzer.com/companies/moxy) | Interdisciplinary studio focused on design and development. | `Porto` |
+| [Noesis](https://www.noesis.pt/pt/homepage) [:rocket:](https://www.noesis.pt/pt/junta-te-a-nos/) [:speech_balloon:](https://pt.teamlyzer.com/companies/noesis-portugal) | Consultancy and enterprise software. | `Lisboa` |
+| [Novabase](http://www.novabase.pt/) [:rocket:](http://www.novabase.pt/en/dp/opportunities) [:speech_balloon:](https://pt.teamlyzer.com/companies/novabase) | Simpler & happier. | `Lisboa` |
+| [Opensoft](https://www.opensoft.pt/) [:rocket:](https://www.opensoft.pt/carreiras/) [:speech_balloon:](https://pt.teamlyzer.com/companies/opensoft) | Making life easier. | `Lisboa` |
+| [Premium Minds](https://www.premium-minds.com/) [:rocket:](https://join.premium-minds.com/) [:speech_balloon:](https://pt.teamlyzer.com/companies/premium-minds) | We build great software for innovative clients. | `Lisboa` |
+| [Present Technologies](https://www.present-technologies.com/) [:rocket:](https://www.present-technologies.com/careers/) [:speech_balloon:](https://pt.teamlyzer.com/companies/present-technologies) | Delivering Quality Software. | `Coimbra` `Porto` <br> `Sertã` |
+| [Syone](https://www.syone.com/) [:rocket:](https://careers.syone.com/) [:speech_balloon:](https://pt.teamlyzer.com/companies/syone) | Outsourcing, nearshore, turnkey projects. | `Alfragide` <br> `Aveiro` `Lisboa` <br>  `Maia` `Matosinhos` <br> `Oeiras` `Porto` |
+| [TMC](https://tmc-employeneurship.com/) [:rocket:](https://www.linkedin.com/company/tmcspain/jobs/) [:speech_balloon:](https://pt.teamlyzer.com/companies/tmc) | Agile software development. | `Porto` |
+| [Ubiwhere](https://ubiwhere.com) [:rocket:](https://www.ubiwhere.com/en/careers) [:speech_balloon:](https://pt.teamlyzer.com/companies/ubiwhere) | Bleeding Edge Technologies with custom R&D. | `Aveiro` `Coimbra` |
+| [VILT Group](https://www.vilt-group.com/) [:rocket:](https://www.vilt-group.com/joinus) [:speech_balloon:](https://pt.teamlyzer.com/companies/vilt-group) | Consultancy and enterprise software. | `Braga` `Lisboa` |
+| [Xpand IT](https://www.xpand-it.com/pt-pt/) [:rocket:](https://www.xpand-it.com/pt-pt/job-opportunities/) [:speech_balloon:](https://pt.teamlyzer.com/companies/xpand-it) | Global consultancy company. | `Braga` `Lisboa` <br> `Porto` <br> `Viana do Castelo` |
 
 
 ## Consultancy :man_office_worker: Recruiting :male_detective:
 
 | Company | Description | Locations |
 | :------ | :---------- | :-------- |
-| [Affinity](https://affinity.pt) [:rocket:](https://affinity.pt/en/careers/) | Consultancy, Outsourcing. | `Lisboa` `Porto` |
-| [AGAP2](http://www.agap2-it.pt/Agap2IT) [:rocket:](http://www.agap2-it.pt/Agap2IT/pt/pages/carreira/) | Consultancy, Outsourcing. | `Lisboa` `Porto` |
-| [Alter Solutions](https://www.alter-solutions.com/pt-pt/) | Consultancy, Outsourcing, and Nearshore projects. | `Lisboa` `Porto` |
-| [Aubay](https://www.aubay.pt/) [:rocket:](https://www.aubay.pt/Home/Opportunities) | Consultancy, Outsourcing, and Nearshore projects. | `Lisboa` `Porto` |
-| [Bee Engineering](https://www.bee-eng.pt/pt/) [:rocket:](https://www.bee-eng.pt/pt/carreira/) | Consultancy, Outsourcing. | `Lisboa` `Porto` |
-| [BOLD International](https://www.boldint.pt/) [:rocket:](https://www.boldint.pt/carreiras/) | Consultancy, Outsourcing. | `Lisboa` `Porto` |
-| [Everis](https://www.everis.com/portugal/pt-pt/home-pt) | Consultancy, Outsourcing. | `Lisboa` |
-| [GLanDrive](https://www.glandrive.pt) | Consultancy, Outsourcing. | `Lisboa` `Porto` |
-| [KCSIT](https://kcsit.pt/) [:rocket:](https://kcsit.pt/pt/carreiras/) | Consultancy, Outsourcing. | `Lisboa` `Porto` |
+| [Affinity](https://affinity.pt) [:rocket:](https://affinity.pt/en/careers/) [:speech_balloon:](https://pt.teamlyzer.com/companies/affinity) | Consultancy, Outsourcing. | `Lisboa` `Porto` |
+| [AGAP2](http://www.agap2-it.pt/Agap2IT) [:rocket:](http://www.agap2-it.pt/Agap2IT/pt/pages/carreira/) [:speech_balloon:](https://pt.teamlyzer.com/companies/agap2-it-portugal) | Consultancy, Outsourcing. | `Lisboa` `Porto` |
+| [Alter Solutions](https://www.alter-solutions.com/pt-pt/) [:speech_balloon:](https://pt.teamlyzer.com/companies/alter-solutions-portugal) | Consultancy, Outsourcing, and Nearshore projects. | `Lisboa` `Porto` |
+| [Aubay](https://www.aubay.pt/) [:rocket:](https://www.aubay.pt/Home/Opportunities) [:speech_balloon:](https://pt.teamlyzer.com/companies/aubay) | Consultancy, Outsourcing, and Nearshore projects. | `Lisboa` `Porto` |
+| [Bee Engineering](https://www.bee-eng.pt/pt/) [:rocket:](https://www.bee-eng.pt/pt/carreira/) [:speech_balloon:](https://pt.teamlyzer.com/companies/bee-engineering-portugal) | Consultancy, Outsourcing. | `Lisboa` `Porto` |
+| [BOLD International](https://www.boldint.pt/) [:rocket:](https://www.boldint.pt/carreiras/) [:speech_balloon:](https://pt.teamlyzer.com/companies/bold-international) | Consultancy, Outsourcing. | `Lisboa` `Porto` |
+| [Everis](https://www.everis.com/portugal/pt-pt/home-pt) [:speech_balloon:](https://pt.teamlyzer.com/companies/everis-portugal) | Consultancy, Outsourcing. | `Lisboa` |
+| [GLanDrive](https://www.glandrive.pt) [:speech_balloon:](https://pt.teamlyzer.com/companies/glandrive) | Consultancy, Outsourcing. | `Lisboa` `Porto` |
+| [KCSIT](https://kcsit.pt/) [:rocket:](https://kcsit.pt/pt/carreiras/) [:speech_balloon:](https://pt.teamlyzer.com/companies/kcs-it) | Consultancy, Outsourcing. | `Lisboa` `Porto` |
 | [KWAN](https://www.kwan.pt/) |  Consultancy, Outsourcing. | `Lisboa` `Porto` |
-| [Landing.jobs](https://landing.jobs) [:rocket:](https://landing.jobs/at/landing-jobs) | Helping people find the right fit tech job. | `Lisboa` |
-| [Multivision](https://multivision.pt) [:rocket:](https://www.linkedin.com/company/multivision---consultoria-em-telecomunica-es-e-inform-tica-lda-/jobs/) | Consultancy, Outsourcing. | `Lisboa` |
-| [Olisipo](https://www.olisipo.pt/) [:rocket:](https://www.olisipo.pt/jobs) | Outsourcing, Training and Early-stage venture capital. | `Aveiro` `Lisboa` <br> `Porto` |
-| [Prime IT](https://www.primeit.pt/) [:rocket:](https://www.primeit.pt/carreiras) | Consultancy, Outsourcing. | `Lisboa` `Porto` |
+| [Landing.jobs](https://landing.jobs) [:rocket:](https://landing.jobs/at/landing-jobs) [:speech_balloon:](https://pt.teamlyzer.com/companies/landing-jobs) | Helping people find the right fit tech job. | `Lisboa` |
+| [Multivision](https://multivision.pt) [:rocket:](https://www.linkedin.com/company/multivision---consultoria-em-telecomunica-es-e-inform-tica-lda-/jobs/) [:speech_balloon:](https://pt.teamlyzer.com/companies/multivision) | Consultancy, Outsourcing. | `Lisboa` |
+| [Olisipo](https://www.olisipo.pt/) [:rocket:](https://www.olisipo.pt/jobs) [:speech_balloon:](https://pt.teamlyzer.com/companies/olisipo) | Outsourcing, Training and Early-stage venture capital. | `Aveiro` `Lisboa` <br> `Porto` |
+| [Prime IT](https://www.primeit.pt/) [:rocket:](https://www.primeit.pt/carreiras) [:speech_balloon:](https://pt.teamlyzer.com/companies/prime-it) | Consultancy, Outsourcing. | `Lisboa` `Porto` |
 
 
 ## Consultancy :man_office_worker: Specialized :dart:
 
 | Company | Description | Locations |
 | :------ | :---------- | :-------- |
-| [BI4ALL](https://www.bi4all.pt/en/) [:rocket:](https://www.linkedin.com/company/bi4all/jobs/) | Consulting services with several analytics solutions.  | `Lisboa` `Porto` |
-| [Critical Software](https://www.criticalsoftware.com) [:rocket:](https://www.criticalsoftware.com/careers) | Mission and business-critical applications. | `Coimbra` `Lisboa` <br> `Porto` |
-| [blockbird Ventures](https://www.blockbird.ventures) [:rocket:](https://blockbird.ventures/careers/) | Blockchain and Ethereum development. | `Lisboa` `Remote` |
+| [BI4ALL](https://www.bi4all.pt/en/) [:rocket:](https://www.linkedin.com/company/bi4all/jobs/) [:speech_balloon:](https://pt.teamlyzer.com/companies/bi4all) | Consulting services with several analytics solutions.  | `Lisboa` `Porto` |
+| [Critical Software](https://www.criticalsoftware.com) [:rocket:](https://www.criticalsoftware.com/careers) [:speech_balloon:](https://pt.teamlyzer.com/companies/critical-software) | Mission and business-critical applications. | `Coimbra` `Lisboa` <br> `Porto` |
+| [blockbird Ventures](https://www.blockbird.ventures) [:rocket:](https://blockbird.ventures/careers/) [:speech_balloon:](https://pt.teamlyzer.com/companies/blockbird-ventures) | Blockchain and Ethereum development. | `Lisboa` `Remote` |
 | [Fruition Partners](https://www.fruitionpartners.nl/) [:rocket:](https://www.it4it-careers.com/) | Consultancy and Application Development based on ServiceNow. | `Fundão` `Lisboa` |
-| [JTA](https://www.thedatascientists.com/) [:rocket:](https://www.thedatascientists.com) | Machine Learning, Reporting and custom vizualizations services. | `Porto` |
-| [Kwanko](https://kwanko.com/) [:rocket:](https://www.kwanko.com/about-us/careers/) | An International leader in Crossdevice Performance Marketing. | `Lisboa` |
+| [JTA](https://www.thedatascientists.com/) [:rocket:](https://www.thedatascientists.com) [:speech_balloon:](https://pt.teamlyzer.com/companies/jta) | Machine Learning, Reporting and custom vizualizations services. | `Porto` |
+| [Kwanko](https://kwanko.com/) [:rocket:](https://www.kwanko.com/about-us/careers/) [:speech_balloon:](https://pt.teamlyzer.com/companies/kwanko) | An International leader in Crossdevice Performance Marketing. | `Lisboa` |
 
 
 ## Consultancy :man_office_worker: Web :globe_with_meridians: Mobile :iphone: Design :art:
 
 | Company | Description | Locations |
 | :------ | :---------- | :-------- |
-| [Bliss Applications](https://www.blissapplications.com/) [:rocket:](https://www.blissapplications.com/careers) | UX/UI & software-driven company. | `Lisboa` `Porto` |
-| [Coletiv](https://www.coletiv.com) [:rocket:](https://coletiv.com/#jobs) | Mobile and backend development. | `Porto` |
-| [Dengun](https://www.dengun.com/en/) [:rocket:](https://www.dengun.com/en/jobs/) | Web, Mobile development and digital marketing. | `Faro` |
-| [Imaginary Cloud](https://www.imaginarycloud.com) [:rocket:](https://www.imaginarycloud.com/careers) | Web, mobile, development and design services. | `Lisboa` |
-| [Load](http://load.digital) [:rocket:](https://consultancy.load.digital/carreiras) | Design Thinking, Web, Mobile, IoT, New Tech (VR, AI, Blockchain) | `Aveiro` `Remote` |
-| [Pixelmatters](http://pixelmatters.com) [:rocket:](http://pixelmatters.com/jobs/) | Digital product design and development company. | `Porto` |
-| [Redlight Software](https://weareredlight.com) | Web and mobile development studio focused on products. | `Coimbra` `Lisboa` |
-| [Runtime Revolution](https://www.runtime-revolution.com/) [:rocket:](https://www.runtime-revolution.com/careers) | Web and mobile product development. | `Lisboa` |
-| [Significa](https://www.significa.pt) [:rocket:](https://www.significa.pt/careers/) | Design and Front-End Web development. | `Porto` |
-| [Subvisual](https://subvisual.com/) | Web development and design firm. | `Braga` |
+| [Bliss Applications](https://www.blissapplications.com/) [:rocket:](https://www.blissapplications.com/careers) [:speech_balloon:](https://pt.teamlyzer.com/companies/bliss-applications) | UX/UI & software-driven company. | `Lisboa` `Porto` |
+| [Coletiv](https://www.coletiv.com) [:rocket:](https://coletiv.com/#jobs) [:speech_balloon:](https://pt.teamlyzer.com/companies/coletiv) | Mobile and backend development. | `Porto` |
+| [Dengun](https://www.dengun.com/en/) [:rocket:](https://www.dengun.com/en/jobs/) [:speech_balloon:](https://pt.teamlyzer.com/companies/dengun) | Web, Mobile development and digital marketing. | `Faro` |
+| [Imaginary Cloud](https://www.imaginarycloud.com) [:rocket:](https://www.imaginarycloud.com/careers) [:speech_balloon:](https://pt.teamlyzer.com/companies/imaginary-cloud) | Web, mobile, development and design services. | `Lisboa` |
+| [Load](http://load.digital) [:rocket:](https://consultancy.load.digital/carreiras) [:speech_balloon:](https://pt.teamlyzer.com/companies/load-interactive) | Design Thinking, Web, Mobile, IoT, New Tech (VR, AI, Blockchain) | `Aveiro` `Remote` |
+| [Pixelmatters](http://pixelmatters.com) [:rocket:](http://pixelmatters.com/jobs/) [:speech_balloon:](https://pt.teamlyzer.com/companies/pixelmatters) | Digital product design and development company. | `Porto` |
+| [Redlight Software](https://weareredlight.com) [:speech_balloon:](https://pt.teamlyzer.com/companies/redlight-software-inc) | Web and mobile development studio focused on products. | `Coimbra` `Lisboa` |
+| [Runtime Revolution](https://www.runtime-revolution.com/) [:rocket:](https://www.runtime-revolution.com/careers) [:speech_balloon:](https://pt.teamlyzer.com/companies/runtime-revolution) | Web and mobile product development. | `Lisboa` |
+| [Significa](https://www.significa.pt) [:rocket:](https://www.significa.pt/careers/) [:speech_balloon:](https://pt.teamlyzer.com/companies/significa) | Design and Front-End Web development. | `Porto` |
+| [Subvisual](https://subvisual.com/) [:speech_balloon:](https://pt.teamlyzer.com/companies/subvisual) | Web development and design firm. | `Braga` |
 | [Thing Pink](http://www.thing-pink.pt) [:rocket:](http://www.thing-pink.pt/joinus) | Digital Agency with focus on Web, Mobile and IoT. | `Lisboa` `Porto` |
-| [Vizzuality](https://www.vizzuality.com) [:rocket:](https://vizzuality.bamboohr.com/jobs/) | Digital Agency focused in having a positive impact in the world. | `Porto` `remote` |
+| [Vizzuality](https://www.vizzuality.com) [:rocket:](https://vizzuality.bamboohr.com/jobs/) [:speech_balloon:](https://pt.teamlyzer.com/companies/vizzuality) | Digital Agency focused in having a positive impact in the world. | `Porto` `remote` |
 | [Waterdog](https://waterdog.mobi/) | Web and Mobile development. | `Porto` |
-| [YLD](https://www.yld.io/) [:rocket:](https://www.yld.io/join-us/) | Software engineering, design, training and open-source. | `Lisboa` `Porto` <br> `Remote` |
+| [YLD](https://www.yld.io/) [:rocket:](https://www.yld.io/join-us/) [:speech_balloon:](https://pt.teamlyzer.com/companies/yld) | Software engineering, design, training and open-source. | `Lisboa` `Porto` <br> `Remote` |
 
 
 ## Developer Tools :hammer_and_wrench:
 
 | Company | Description | Locations |
 | :------ | :---------- | :-------- |
-| [Codacy](https://www.codacy.com) [:rocket:](https://www.codacy.com/careers) | Automated code reviews & code analytics. | `Lisboa` `Remote` |
-| [DashDash](https://dashdash.com) [:rocket:](https://github.com/dashdash/hiring) | Create interactive web apps using spreadsheet skills. | `Porto` |
-| [Oracle](https://www.oracle.com/index.html) [:rocket:](https://www.oracle.com/corporate/careers/) | DBMS's and information systems. | `Oeiras` `Remote` |
-| [OutSystems](https://www.outsystems.com) [:rocket:](https://www.outsystems.com/company/careers/) | Low-code platform to visually develop applications. | `Braga` `Linda-a-Velha` <br> `Proença-a-Nova` |
-| [Unbabel](https://unbabel.com) [:rocket:](https://unbabel.com/careers/) | Translation as a Service. | `Lisboa` |
+| [Codacy](https://www.codacy.com) [:rocket:](https://www.codacy.com/careers) [:speech_balloon:](https://pt.teamlyzer.com/companies/codacy) | Automated code reviews & code analytics. | `Lisboa` `Remote` |
+| [DashDash](https://dashdash.com) [:rocket:](https://github.com/dashdash/hiring) [:speech_balloon:](https://pt.teamlyzer.com/companies/dashdash) | Create interactive web apps using spreadsheet skills. | `Porto` |
+| [Oracle](https://www.oracle.com/index.html) [:rocket:](https://www.oracle.com/corporate/careers/) [:speech_balloon:](https://pt.teamlyzer.com/companies/oracle) | DBMS's and information systems. | `Oeiras` `Remote` |
+| [OutSystems](https://www.outsystems.com) [:rocket:](https://www.outsystems.com/company/careers/) [:speech_balloon:](https://pt.teamlyzer.com/companies/outsystems) | Low-code platform to visually develop applications. | `Braga` `Linda-a-Velha` <br> `Proença-a-Nova` |
+| [Unbabel](https://unbabel.com) [:rocket:](https://unbabel.com/careers/) [:speech_balloon:](https://pt.teamlyzer.com/companies/unbabel) | Translation as a Service. | `Lisboa` |
 
 
 ## E-commerce :shopping:
 
 | Company | Description | Locations |
 | :------ | :---------- | :-------- |
-| [360imprimir](https://www.360imprimir.pt/) [:rocket:](https://www.360imprimir.pt/Home/Carreiras) | Online platform for marketing products and services. | `Braga` `Lisboa` <br> `Torres Vedras` |
-| [Aptoide](https://www.aptoide.com/) [:rocket:](https://co.aptoide.com/jobs) | Your Android app store. | `Lisboa` |
-| [Blip](https://blip.pt) [:rocket:](https://blip.pt/jobs/) | Online betting and gambling operator. | `Porto` |
-| [Farfetch](https://www.farfetch.com) [:rocket:](https://www.farfetch.com/pt/careers) | Global technology platform for luxury fashion. | `Braga` `Lisboa` <br> `Porto` |
+| [360imprimir](https://www.360imprimir.pt/) [:rocket:](https://www.360imprimir.pt/Home/Carreiras) [:speech_balloon:](https://pt.teamlyzer.com/companies/360-imprimir) | Online platform for marketing products and services. | `Braga` `Lisboa` <br> `Torres Vedras` |
+| [Aptoide](https://www.aptoide.com/) [:rocket:](https://co.aptoide.com/jobs) [:speech_balloon:](https://pt.teamlyzer.com/companies/aptoide) | Your Android app store. | `Lisboa` |
+| [Blip](https://blip.pt) [:rocket:](https://blip.pt/jobs/) [:speech_balloon:](https://pt.teamlyzer.com/companies/blip) | Online betting and gambling operator. | `Porto` |
+| [Farfetch](https://www.farfetch.com) [:rocket:](https://www.farfetch.com/pt/careers) [:speech_balloon:](https://pt.teamlyzer.com/companies/farfetch) | Global technology platform for luxury fashion. | `Braga` `Lisboa` <br> `Porto` |
 | [Jumia](https://group.jumia.com) [:rocket:](https://group.jumia.com/careers) | Online Shopping for Electronics, Phones & Fashion in Africa. | `Porto` |
-| [Jumpseller](https://jumpseller.com) [:rocket:](https://jumpseller.com/jobs) | E-commerce platform to create online stores. | `Porto` |
-| [La Redoute](https://www.laredoute-corporate.com/en/homepage/) [:rocket:](https://www.linkedin.com/company/la-redoute/jobs/) | Home & Fashion online. | `Leiria` |
-| [OLX](https://www.olxgroup.com) [:rocket:](https://www.olxgroup.com/search/all-functions/portugal-lisbon/all-brands) | Network of market-leading trading platforms across 5 countries. | `Lisboa` |
-| [Platforme](https://platforme.com) [:rocket:](https://platforme.com/jobs) | Dynamic product as a service. Leaders in customisation. | `Porto` |
-| [Prozis](https://www.prozis.com/pt/en) [:rocket:](https://prozis.breezy.hr/) | Sports and nutrition online store. |  `Aveiro` `Esposende` <br> `Porto` |
-| [Salsify](https://www.salsify.com) [:rocket:](https://www.salsify.com/careers) | Product Experience Management and Syndication platform. | `Lisboa` |
-| [Trouva](https://www.trouva.com) [:rocket:](https://trouva.workable.com/) | Marketplace for independent boutiques. | `Lisboa` |
-| [Uniplaces](https://www.uniplaces.com/) [:rocket:](https://careers.uniplaces.com/) | Student accomodation platform. | `Lisboa` |
+| [Jumpseller](https://jumpseller.com) [:rocket:](https://jumpseller.com/jobs) [:speech_balloon:](https://pt.teamlyzer.com/companies/jumpseller) | E-commerce platform to create online stores. | `Porto` |
+| [La Redoute](https://www.laredoute-corporate.com/en/homepage/) [:rocket:](https://www.linkedin.com/company/la-redoute/jobs/) [:speech_balloon:](https://pt.teamlyzer.com/companies/la-redoute-portugal) | Home & Fashion online. | `Leiria` |
+| [OLX](https://www.olxgroup.com) [:rocket:](https://www.olxgroup.com/search/all-functions/portugal-lisbon/all-brands) [:speech_balloon:](https://pt.teamlyzer.com/companies/olx-group) | Network of market-leading trading platforms across 5 countries. | `Lisboa` |
+| [Platforme](https://platforme.com) [:rocket:](https://platforme.com/jobs) [:speech_balloon:](https://pt.teamlyzer.com/companies/platforme) | Dynamic product as a service. Leaders in customisation. | `Porto` |
+| [Prozis](https://www.prozis.com/pt/en) [:rocket:](https://prozis.breezy.hr/) [:speech_balloon:](https://pt.teamlyzer.com/companies/prozis) | Sports and nutrition online store. |  `Aveiro` `Esposende` <br> `Porto` |
+| [Salsify](https://www.salsify.com) [:rocket:](https://www.salsify.com/careers) [:speech_balloon:](https://pt.teamlyzer.com/companies/salsify) | Product Experience Management and Syndication platform. | `Lisboa` |
+| [Trouva](https://www.trouva.com) [:rocket:](https://trouva.workable.com/) [:speech_balloon:](https://pt.teamlyzer.com/companies/trouva) | Marketplace for independent boutiques. | `Lisboa` |
+| [Uniplaces](https://www.uniplaces.com/) [:rocket:](https://careers.uniplaces.com/) [:speech_balloon:](https://pt.teamlyzer.com/companies/uniplaces) | Student accomodation platform. | `Lisboa` |
 
 
 ## Education :books:
 
 | Company | Description | Locations |
 | :------ | :---------- | :-------- |
-| [DreamShaper](https://dreamshaper.com/) | Classroom tools to improve student work related skills. | `Lisboa` `Porto` <br> `Remote` |
-| [Edubox](https://edubox.pt) [:rocket:](https://edubox.pt/candidaturas)| Educational solutions and school management software. | `Aveiro` |
-| [ELSA](https://elsaspeak.com/) [:rocket:](https://elsaspeak.com/careers)| AI-powered tool to improve pronunciation skills. | `Lisboa` `Remote` |
+| [DreamShaper](https://dreamshaper.com/) [:speech_balloon:](https://pt.teamlyzer.com/companies/dreamshaper) | Classroom tools to improve student work related skills. | `Lisboa` `Porto` <br> `Remote` |
+| [Edubox](https://edubox.pt) [:rocket:](https://edubox.pt/candidaturas) [:speech_balloon:](https://pt.teamlyzer.com/companies/edubox) | Educational solutions and school management software. | `Aveiro` |
+| [ELSA](https://elsaspeak.com/) [:rocket:](https://elsaspeak.com/careers) [:speech_balloon:](https://pt.teamlyzer.com/companies/elsa) | AI-powered tool to improve pronunciation skills. | `Lisboa` `Remote` |
 | [MUSa Software](https://musasoftware.com/) | ERP and web products for art schools. | `Viana do Castelo` |
 
 
@@ -181,58 +181,58 @@ Are you seeking for a job? Click :rocket: to check the company's careers page.
 | :------ | :---------- | :-------- |
 | [Amplemarket](https://amplemarket.com/) [:rocket:](https://amplemarket.com/careers) | AI powered sales assistant. | `Lisboa` |
 | [ClanHR](https://www.clanhr.com) | Online Human Resources Management Software. | `Lisboa` |
-| [Critical Manufacturing](https://www.criticalmanufacturing.com) [:rocket:](https://www.criticalmanufacturing.com/en/careers) | Manufacturing business-critical applications. | `Porto` |
+| [Critical Manufacturing](https://www.criticalmanufacturing.com) [:rocket:](https://www.criticalmanufacturing.com/en/careers) [:speech_balloon:](https://pt.teamlyzer.com/companies/critical-manufacturing) | Manufacturing business-critical applications. | `Porto` |
 | [Elecnor Deimos](http://www.elecnor-deimos.com/) [:rocket:](http://www.elecnor-deimos.com/jobs/) | Advanced design solutions and turn-key space software systems. | `Lisboa` |
-| [Glintt](https://www.glintt.com/) [:rocket:](https://www.glintt.com/pt/carreiras/ofertas/Paginas/Ofertas.aspx) | Healthcare software. | `Algarve` `Lisboa` <br> `Porto` `Sintra` |
-| [GMV](https://www.gmv.com/) [:rocket:](https://www.gmv.com/pt/Emprego/) | Advanced solutions in many sectors. | `Lisboa` |
-| [Hitachi Vantara](https://www.hitachivantara.com/) [:rocket:](https://www.hitachivantara.com/en-us/company/careers.html) | IoT, cloud, application, big data and analytics solutions. | `Oeiras` `Porto` |
-| [InnovationCast](https://innovationcast.com/) | Collaborative Innovation Management Software. | `Lisboa` `Porto` |
-| [InvoiceXpress](https://www.invoicexpress.com/) | Online Invoicing Software. | `Lisboa` |
-| [KEEP SOLUTIONS](https://www.keep.pt/) [:rocket:](https://www.keep.pt/empresa/carreiras/) | Advanced solutions for information management. | `Braga` `Remote` |
-| [kununu](https://www.kununu.com/) [:rocket:](https://corporate.xing.com/en/career/porto/) | Workplace insights that matter. | `Porto` |
+| [Glintt](https://www.glintt.com/) [:rocket:](https://www.glintt.com/pt/carreiras/ofertas/Paginas/Ofertas.aspx) [:speech_balloon:](https://pt.teamlyzer.com/companies/glintt) | Healthcare software. | `Algarve` `Lisboa` <br> `Porto` `Sintra` |
+| [GMV](https://www.gmv.com/) [:rocket:](https://www.gmv.com/pt/Emprego/) [:speech_balloon:](https://pt.teamlyzer.com/companies/gmv) | Advanced solutions in many sectors. | `Lisboa` |
+| [Hitachi Vantara](https://www.hitachivantara.com/) [:rocket:](https://www.hitachivantara.com/en-us/company/careers.html) [:speech_balloon:](https://pt.teamlyzer.com/companies/hitachi-vantara) | IoT, cloud, application, big data and analytics solutions. | `Oeiras` `Porto` |
+| [InnovationCast](https://innovationcast.com/) [:speech_balloon:](https://pt.teamlyzer.com/companies/innovationcast) | Collaborative Innovation Management Software. | `Lisboa` `Porto` |
+| [InvoiceXpress](https://www.invoicexpress.com/) [:speech_balloon:](https://pt.teamlyzer.com/companies/invoicexpress) | Online Invoicing Software. | `Lisboa` |
+| [KEEP SOLUTIONS](https://www.keep.pt/) [:rocket:](https://www.keep.pt/empresa/carreiras/) [:speech_balloon:](https://pt.teamlyzer.com/companies/keep-solutions) | Advanced solutions for information management. | `Braga` `Remote` |
+| [kununu](https://www.kununu.com/) [:rocket:](https://corporate.xing.com/en/career/porto/) [:speech_balloon:](https://pt.teamlyzer.com/companies/kununu) | Workplace insights that matter. | `Porto` |
 | [Mind](http://www.mind.pt/) | Information management and industrial systems. | `Lisboa` `Porto` |
-| [Nmbrs](https://www.nmbrs.com/) [:rocket:](https://jobs.nmbrs.com/) | HR & Payroll software. | `Lisboa` |
-| [Petapilot](https://www.petapilot.com/) [:rocket:](https://www.petapilot.com/careers) | Big Data Solutions. | `Porto` |
-| [PHC Software](https://www.phcsoftware.com/) [:rocket:](https://www.phcsoftware.com/carreiras/) | ERP software. | `Lisboa` `Porto` |
-| [Primavera BSS](https://pt.primaverabss.com/pt/) [:rocket:](https://pt.primaverabss.com/pt/bolsaempregos/) | Enterprise resource planning software. | `Braga` `Leiria` <br> `Lisboa` |
-| [Quidgest](https://quidgest.com/) [:rocket:](https://quidgest.com/quidgest/recrutamento/) | Information systems and ERP software. | `Lisboa` |
-| [Sherpany](https://www.sherpany.com/) [:rocket:](https://www.sherpany.com/en/careers/) | Meeting Management Software for Leaders. | `Lisboa` `Remote` |
-| [Unit4](https://www.unit4.com/) [:rocket:](https://www.careers.unit4.com/) | ERP, Consulting. | `Algés` |
-| [VAKT Global Ltd.](https://www.vakt.com/) [:rocket:](https://www.vakt.com/careers/) | Enterprise grade blockchain commodities trading platform. | `Lisboa` |
-| [VOID Software](https://www.void.pt/)  | Systems design & architecture using different technology stacks. | `Leiria` |
-| [WeDo Technologies](https://www.wedotechnologies.com/) [:rocket:](https://www.wedotechnologies.com/en/careers/) | Revenue Assurance and Fraud Management solutions. | `Braga` `Lisboa` |
+| [Nmbrs](https://www.nmbrs.com/) [:rocket:](https://jobs.nmbrs.com/) [:speech_balloon:](https://pt.teamlyzer.com/companies/nmbrs-bv) | HR & Payroll software. | `Lisboa` |
+| [Petapilot](https://www.petapilot.com/) [:rocket:](https://www.petapilot.com/careers) [:speech_balloon:](https://pt.teamlyzer.com/companies/petapilot) | Big Data Solutions. | `Porto` |
+| [PHC Software](https://www.phcsoftware.com/) [:rocket:](https://www.phcsoftware.com/carreiras/) [:speech_balloon:](https://pt.teamlyzer.com/companies/phc-software) | ERP software. | `Lisboa` `Porto` |
+| [Primavera BSS](https://pt.primaverabss.com/pt/) [:rocket:](https://pt.primaverabss.com/pt/bolsaempregos/) [:speech_balloon:](https://pt.teamlyzer.com/companies/primavera-bss) | Enterprise resource planning software. | `Braga` `Leiria` <br> `Lisboa` |
+| [Quidgest](https://quidgest.com/) [:rocket:](https://quidgest.com/quidgest/recrutamento/) [:speech_balloon:](https://pt.teamlyzer.com/companies/quidgest) | Information systems and ERP software. | `Lisboa` |
+| [Sherpany](https://www.sherpany.com/) [:rocket:](https://www.sherpany.com/en/careers/) [:speech_balloon:](https://pt.teamlyzer.com/companies/sherpany) | Meeting Management Software for Leaders. | `Lisboa` `Remote` |
+| [Unit4](https://www.unit4.com/) [:rocket:](https://www.careers.unit4.com/) [:speech_balloon:](https://pt.teamlyzer.com/companies/unit4) | ERP, Consulting. | `Algés` |
+| [VAKT Global Ltd.](https://www.vakt.com/) [:rocket:](https://www.vakt.com/careers/) [:speech_balloon:](https://pt.teamlyzer.com/companies/vakt) | Enterprise grade blockchain commodities trading platform. | `Lisboa` |
+| [VOID Software](https://www.void.pt/) [:speech_balloon:](https://pt.teamlyzer.com/companies/void-software) | Systems design & architecture using different technology stacks. | `Leiria` |
+| [WeDo Technologies](https://www.wedotechnologies.com/) [:rocket:](https://www.wedotechnologies.com/en/careers/) [:speech_balloon:](https://pt.teamlyzer.com/companies/wedo-technologies) | Revenue Assurance and Fraud Management solutions. | `Braga` `Lisboa` |
 
 
 ## FinTech :moneybag:
 
 | Company | Description | Locations |
 | :------ | :---------- | :-------- |
-| [Banco Atlântico Europa](https://www.atlantico.eu/) [:rocket:](https://www.atlantico.eu/carreiras) | An European bank, under the supervision of Banco de Portugal. | `Lisboa` |
-| [Compare Group](http://www.compareeuropegroup.com/) [:rocket:](http://www.compareeuropegroup.com/careers/) | Financial products comparision for several markets (eg: [ComparaJá](https://www.comparaja.pt)). | `Lisboa` |
-| [Euronext](https://www.euronext.com) [:rocket:](https://www.euronext.com/en/careers) | European stock exchange operator. | `Porto` |
-| [Feedzai](https://feedzai.com) [:rocket:](https://careers.feedzai.com) | Fraud detection platform to make commerce safe. | `Coimbra` `Lisboa` <br> `Porto` |
+| [Banco Atlântico Europa](https://www.atlantico.eu/) [:rocket:](https://www.atlantico.eu/carreiras) [:speech_balloon:](https://pt.teamlyzer.com/companies/banco-privado-atlantico-europa) | An European bank, under the supervision of Banco de Portugal. | `Lisboa` |
+| [Compare Group](http://www.compareeuropegroup.com/) [:rocket:](http://www.compareeuropegroup.com/careers/) [:speech_balloon:](https://pt.teamlyzer.com/companies/compareeuropegroup) | Financial products comparision for several markets (eg: [ComparaJá](https://www.comparaja.pt)). | `Lisboa` |
+| [Euronext](https://www.euronext.com) [:rocket:](https://www.euronext.com/en/careers) [:speech_balloon:](https://pt.teamlyzer.com/companies/euronext-s-technology-centre-portugal) | European stock exchange operator. | `Porto` |
+| [Feedzai](https://feedzai.com) [:rocket:](https://careers.feedzai.com) [:speech_balloon:](https://pt.teamlyzer.com/companies/feedzai) | Fraud detection platform to make commerce safe. | `Coimbra` `Lisboa` <br> `Porto` |
 | [Fidel](https://fidel.uk) [:rocket:](https://fidel.uk/careers/) | One API for linking bank cards to digital applications, globally. | `Lisboa` |
 | [Fractal](https://company.fractal.id) | Enabling open finance with a new Internet Identity layer. | `Porto` `Remote` |
-| [Iban Wallet](https://www.ibanwallet.com) | Invest in secured loans. | `Lisboa` |
-| [ITSector](https://www.itsector.pt/pt) [:rocket:](https://www.itsector.pt/pt/carreiras) | Software for financial institutions. | `Aveiro` `Braga` <br> `Bragança` `Lisboa` <br> `Porto` |
+| [Iban Wallet](https://www.ibanwallet.com) [:speech_balloon:](https://pt.teamlyzer.com/companies/iban) | Invest in secured loans. | `Lisboa` |
+| [ITSector](https://www.itsector.pt/pt) [:rocket:](https://www.itsector.pt/pt/carreiras) [:speech_balloon:](https://pt.teamlyzer.com/companies/itsector) | Software for financial institutions. | `Aveiro` `Braga` <br> `Bragança` `Lisboa` <br> `Porto` |
 | [JUMO](https://www.jumo.world) [:rocket:](https://www.jumo.world/careers) | Financial inclusion platform. | `Porto` |
-| [LoanDolphin](https://loandolphin.com.au/) [:rocket:](https://loandolphin.breezy.hr/) | Home loan marketplace. | `Lisboa` `Remote` |
-| [Natixis](https://www.natixis.com/) [:rocket:](https://www.natixis.com/natixis/jcms/tki_5051/en/careers) | French corporate and investment bank. | `Porto` |
-| [Onfido](https://www.onfido.com) [:rocket:](https://onfido.com/jobs/) | Identity verification at the speed of life. | `Lisboa` |
-| [Seedrs](https://www.seedrs.com) [:rocket:](https://www.seedrs.com/careers) | Equity marketplace for everyone. | `Lisboa` |
-| [Uphold](https://uphold.com/) [:rocket:](https://uphold.com/en/about-us/careers) | US cloud based financial services platform. | `Braga` |
+| [LoanDolphin](https://loandolphin.com.au/) [:rocket:](https://loandolphin.breezy.hr/) [:speech_balloon:](https://pt.teamlyzer.com/companies/loandolphin) | Home loan marketplace. | `Lisboa` `Remote` |
+| [Natixis](https://www.natixis.com/) [:rocket:](https://www.natixis.com/natixis/jcms/tki_5051/en/careers) [:speech_balloon:](https://pt.teamlyzer.com/companies/natixis) | French corporate and investment bank. | `Porto` |
+| [Onfido](https://www.onfido.com) [:rocket:](https://onfido.com/jobs/) [:speech_balloon:](https://pt.teamlyzer.com/companies/onfido-background-checks) | Identity verification at the speed of life. | `Lisboa` |
+| [Seedrs](https://www.seedrs.com) [:rocket:](https://www.seedrs.com/careers) [:speech_balloon:](https://pt.teamlyzer.com/companies/seedrs) | Equity marketplace for everyone. | `Lisboa` |
+| [Uphold](https://uphold.com/) [:rocket:](https://uphold.com/en/about-us/careers) [:speech_balloon:](https://pt.teamlyzer.com/companies/uphold-inc) | US cloud based financial services platform. | `Braga` |
 
 
 ## Gaming :video_game:
 
 | Company | Description | Locations |
 | :------ | :---------- | :-------- |
-| [Fabamaq](https://www.fabamaq.com/) [:rocket:](https://www.fabamaq.com/pages.php?page_id=311) | Casino digital games. | `Porto` |
+| [Fabamaq](https://www.fabamaq.com/) [:rocket:](https://www.fabamaq.com/pages.php?page_id=311) [:speech_balloon:](https://pt.teamlyzer.com/companies/fabamaq) | Casino digital games. | `Porto` |
 | [Fun Punch Games](https://funpunchgames.com/) | Independent game development studio. | `Lisboa` |
-| [Ground Control](http://www.gcontrolgames.com/) | Indie games/VR studio. | `Porto` |
-| [Miniclip](https://www.miniclip.com/) [:rocket:](https://corporate.miniclip.com/careers/) | Mobile and web game development company. | `Lisboa` |
+| [Ground Control](http://www.gcontrolgames.com/) [:speech_balloon:](https://pt.teamlyzer.com/companies/ground-control-studios) | Indie games/VR studio. | `Porto` |
+| [Miniclip](https://www.miniclip.com/) [:rocket:](https://corporate.miniclip.com/careers/) [:speech_balloon:](https://pt.teamlyzer.com/companies/miniclip-games) | Mobile and web game development company. | `Lisboa` |
 | [Not a Game Studio](http://www.notagamestudio.com/) | Game development studio focused on the experience of the users. | `Lisboa` |
-| [ZPX](https://www.zpx.pt/) [:rocket:](https://zpx.pt/careers.html) | Full-range game development studio offering design, art, coding. | `Lisboa` |
+| [ZPX](https://www.zpx.pt/) [:rocket:](https://zpx.pt/careers.html) [:speech_balloon:](https://pt.teamlyzer.com/companies/zpx-zona-paradoxal) | Full-range game development studio offering design, art, coding. | `Lisboa` |
 
 
 ## Medical :hospital:
@@ -246,68 +246,68 @@ Are you seeking for a job? Click :rocket: to check the company's careers page.
 
 | Company | Description | Locations |
 | :------ | :---------- | :-------- |
-| [Glookast](https://www.glookast.com/) | Solving the media workflow puzzle. | `Matosinhos` |
-| [MediaGaps](http://www.mediagaps.com/) | Bridging your workflow gaps. | `Porto` |
-| [MOG Technologies](https://www.mog-technologies.com) [:rocket:](https://www.mog-technologies.com/careers-at-mog/) | End-to-end solutions for professional media. | `Porto` |
-| [Sky](https://www.sky.com) [:rocket:](https://careers.sky.com) | TV, broadband, talk, streaming and mobile. | `Lisboa` |
+| [Glookast](https://www.glookast.com/) [:speech_balloon:](https://pt.teamlyzer.com/companies/glookast) | Solving the media workflow puzzle. | `Matosinhos` |
+| [MediaGaps](http://www.mediagaps.com/) [:speech_balloon:](https://pt.teamlyzer.com/companies/mediagaps) | Bridging your workflow gaps. | `Porto` |
+| [MOG Technologies](https://www.mog-technologies.com) [:rocket:](https://www.mog-technologies.com/careers-at-mog/) [:speech_balloon:](https://pt.teamlyzer.com/companies/mog) | End-to-end solutions for professional media. | `Porto` |
+| [Sky](https://www.sky.com) [:rocket:](https://careers.sky.com) [:speech_balloon:](https://pt.teamlyzer.com/companies/sky) | TV, broadband, talk, streaming and mobile. | `Lisboa` |
 
 
 ## Sea :ocean:
 
 | Company | Description | Locations |
 | :------ | :---------- | :-------- |
-| [Abyssal](https://abyssal.eu) [:rocket:](https://abyssal.eu/careers/) | 3D Visualization, Simulation and Digitalization for subsea operations. | `Porto` |
+| [Abyssal](https://abyssal.eu) [:rocket:](https://abyssal.eu/careers/) [:speech_balloon:](https://pt.teamlyzer.com/companies/abyssal) | 3D Visualization, Simulation and Digitalization for subsea operations. | `Porto` |
 | [OceanScan-MST](https://www.oceanscan-mst.com) [:rocket:](http://www.oceanscan-mst.com/job-opportunities/) | Lightweight Autonomous Underwater Vehicle manufacturer. | `Porto` |
-| [Xsealence](https://www.xsealence.pt) | Solutions for command, control and monitoring of maritime applications. | `Oeiras` |
+| [Xsealence](https://www.xsealence.pt) [:speech_balloon:](https://pt.teamlyzer.com/companies/xsealence) | Solutions for command, control and monitoring of maritime applications. | `Oeiras` |
 
 
 ## Security :lock:
 
 | Company | Description | Locations |
 | :------ | :---------- | :-------- |
-| [Adamant Sec](https://adamantsec.com/) | Pentesting, consulting and audit. | `Porto` |
-| [Blaze Information Security](https://www.blazeinfosec.com/) | Pentesting, consulting and research. | `Porto` |
+| [Adamant Sec](https://adamantsec.com/) [:speech_balloon:](https://pt.teamlyzer.com/companies/adamant) | Pentesting, consulting and audit. | `Porto` |
+| [Blaze Information Security](https://www.blazeinfosec.com/) [:speech_balloon:](https://pt.teamlyzer.com/companies/blaze-information-security) | Pentesting, consulting and research. | `Porto` |
 | [Char49](https://www.char49.com/) | Pentesting, consulting and training. | `Lisboa` |
-| [Checkmarx](https://www.checkmarx.com/) [:rocket:](https://www.checkmarx.com/company/careers/) | Manage Software Exposure at the Speed of DevOps. | `Braga` |
+| [Checkmarx](https://www.checkmarx.com/) [:rocket:](https://www.checkmarx.com/company/careers/) [:speech_balloon:](https://pt.teamlyzer.com/companies/checkmarx-portugal) | Manage Software Exposure at the Speed of DevOps. | `Braga` |
 | [Cybersafe](https://www.cybersafe.pt/) | Training, solutions integrator and managed security services. | `Alfragide` |
-| [Dashlane](https://www.dashlane.com/) [:rocket:](https://www.dashlane.com/about/careers) | Password manager and online security app. | `Lisboa` |
-| [Dognaedis](https://www.dognaedis.com/) | Security services for enterprises and government agencies. | `Coimbra` `Lisboa` <br> `Porto` |
-| [Fyde](https://www.fyde.com/) [:rocket:](https://www.fyde.com/jobs) | Software-defined remote access and security solution. | `Porto` |
-| [Integrity](https://www.integrity.pt/) [:rocket:](https://www.integrity.pt/careers.html) | Consulting and tech audit focused on information Security. | `Lisboa` |
-| [JScrambler](https://jscrambler.com) [:rocket:](https://jscrambler.com/careers) | JavaScript application integrity and security. | `Porto` |
-| [Layer8](https://www.layer8.pt) | Consulting, technology and security managed services. | `Lisboa` |
-| [Multicert](https://www.multicert.com) [:rocket:](https://www.multicert.com/pt/sobre-nos/recrutamento/) | CA, enterprise security software products and consulting. | `Lisboa` `Porto` |
-| [Probely](https://probely.com) [:rocket:](https://careers.probely.com) | Automated web application security scanning as a service. | `Lisboa` |
-| [S21sec](https://www.s21sec.com) [:rocket:](https://www.s21sec.com/en/careers/) | Cybersecurity services. | `Lisboa` `Porto` |
-| [Symantec](https://www.symantec.com) [:rocket:](https://www.symantec.com/about/careers) | Enterprise and Consumer Security Products. | `Coimbra` `Remote` |
+| [Dashlane](https://www.dashlane.com/) [:rocket:](https://www.dashlane.com/about/careers) [:speech_balloon:](https://pt.teamlyzer.com/companies/dashlane) | Password manager and online security app. | `Lisboa` |
+| [Dognaedis](https://www.dognaedis.com/) [:speech_balloon:](https://pt.teamlyzer.com/companies/dognaedis) | Security services for enterprises and government agencies. | `Coimbra` `Lisboa` <br> `Porto` |
+| [Fyde](https://www.fyde.com/) [:rocket:](https://www.fyde.com/jobs) [:speech_balloon:](https://pt.teamlyzer.com/companies/fyde) | Software-defined remote access and security solution. | `Porto` |
+| [Integrity](https://www.integrity.pt/) [:rocket:](https://www.integrity.pt/careers.html) [:speech_balloon:](https://pt.teamlyzer.com/companies/integrity) | Consulting and tech audit focused on information Security. | `Lisboa` |
+| [JScrambler](https://jscrambler.com) [:rocket:](https://jscrambler.com/careers) [:speech_balloon:](https://pt.teamlyzer.com/companies/jscrambler) | JavaScript application integrity and security. | `Porto` |
+| [Layer8](https://www.layer8.pt) [:speech_balloon:](https://pt.teamlyzer.com/companies/layer8) | Consulting, technology and security managed services. | `Lisboa` |
+| [Multicert](https://www.multicert.com) [:rocket:](https://www.multicert.com/pt/sobre-nos/recrutamento/) [:speech_balloon:](https://pt.teamlyzer.com/companies/multicert) | CA, enterprise security software products and consulting. | `Lisboa` `Porto` |
+| [Probely](https://probely.com) [:rocket:](https://careers.probely.com) [:speech_balloon:](https://pt.teamlyzer.com/companies/probe-ly) | Automated web application security scanning as a service. | `Lisboa` |
+| [S21sec](https://www.s21sec.com) [:rocket:](https://www.s21sec.com/en/careers/) [:speech_balloon:](https://pt.teamlyzer.com/companies/s21sec) | Cybersecurity services. | `Lisboa` `Porto` |
+| [Symantec](https://www.symantec.com) [:rocket:](https://www.symantec.com/about/careers) [:speech_balloon:](https://pt.teamlyzer.com/companies/symantec) | Enterprise and Consumer Security Products. | `Coimbra` `Remote` |
 
 
 ## Social :couple:
 
 | Company | Description | Locations |
 | :------ | :---------- | :-------- |
-| [XING](https://www.xing.com/) [:rocket:](https://corporate.xing.com/en/career/porto/) | For a better working life. | `Porto` |
-| [YouClap](https://youclap.tech) | Create, participate and share awesome challenges. | `Aveiro` `Remote` |
+| [XING](https://www.xing.com/) [:rocket:](https://corporate.xing.com/en/career/porto/) [:speech_balloon:](https://pt.teamlyzer.com/companies/xing) | For a better working life. | `Porto` |
+| [YouClap](https://youclap.tech) [:speech_balloon:](https://pt.teamlyzer.com/companies/youclap) | Create, participate and share awesome challenges. | `Aveiro` `Remote` |
 
 
 ## Telcos :telephone_receiver:
 
 | Company | Description | Locations |
 | :------ | :---------- | :-------- |
-| [Altice Labs](http://www.alticelabs.com/pt/) | Telecommunications technologies. | `Aveiro` |
-| [Carrot](https://carrotincentives.com/)  | ICM for Telco companies.  | `Lisboa` |
-| [Celfocus](https://www.celfocus.com/) [:rocket:](https://www.celfocus.com/home/who-we-are/join-us) | Vodafone technology development.  | `Lisboa` `Porto` |
-| [GoContact](https://www.gocontact.pt/) [:rocket:](https://www.gocontact.pt/recrutamento/) | Company specialized in integrated solutions for Contact Centers. | `Aveiro` `Lisboa` <br> `Porto`|
-| [Readiness IT](https://readinessit.com/) [:rocket:](https://readinessit.com/careers/) | Telecommunications technologies. | `Fundão` `Lisboa` <br> `Porto` `Remote` |
-| [Talkdesk](https://www.talkdesk.com) [:rocket:](https://www.talkdesk.com/careers/) | Enterprise cloud contact center. | `Aveiro` `Coimbra` <br> `Lisboa` `Porto` |
-| [WIT Software](https://www.wit-software.com) [:rocket:](https://www.wit-software.com/careers/) | Software development for telcom services (OTT, RCS, Mobile, Web & others). | `Aveiro` `Coimbra` <br> `Leiria` `Lisboa` <br>`Porto` |
-| [Truphone](https://www.truphone.com) [:rocket:](https://www.truphone.com/careers/) | Global mobile connectivity and eSIM technology innovator. | `Lisboa` |
+| [Altice Labs](http://www.alticelabs.com/pt/) [:speech_balloon:](https://pt.teamlyzer.com/companies/alticelabs) | Telecommunications technologies. | `Aveiro` |
+| [Carrot](https://carrotincentives.com/) | ICM for Telco companies.  | `Lisboa` |
+| [Celfocus](https://www.celfocus.com/) [:rocket:](https://www.celfocus.com/home/who-we-are/join-us) [:speech_balloon:](https://pt.teamlyzer.com/companies/celfocus) | Vodafone technology development.  | `Lisboa` `Porto` |
+| [GoContact](https://www.gocontact.pt/) [:rocket:](https://www.gocontact.pt/recrutamento/) [:speech_balloon:](https://pt.teamlyzer.com/companies/go-contact) | Company specialized in integrated solutions for Contact Centers. | `Aveiro` `Lisboa` <br> `Porto`|
+| [Readiness IT](https://readinessit.com/) [:rocket:](https://readinessit.com/careers/) [:speech_balloon:](https://pt.teamlyzer.com/companies/readiness-it) | Telecommunications technologies. | `Fundão` `Lisboa` <br> `Porto` `Remote` |
+| [Talkdesk](https://www.talkdesk.com) [:rocket:](https://www.talkdesk.com/careers/) [:speech_balloon:](https://pt.teamlyzer.com/companies/talkdesk) | Enterprise cloud contact center. | `Aveiro` `Coimbra` <br> `Lisboa` `Porto` |
+| [WIT Software](https://www.wit-software.com) [:rocket:](https://www.wit-software.com/careers/) [:speech_balloon:](https://pt.teamlyzer.com/companies/wit-software) | Software development for telcom services (OTT, RCS, Mobile, Web & others). | `Aveiro` `Coimbra` <br> `Leiria` `Lisboa` <br>`Porto` |
+| [Truphone](https://www.truphone.com) [:rocket:](https://www.truphone.com/careers/) [:speech_balloon:](https://pt.teamlyzer.com/companies/truphone) | Global mobile connectivity and eSIM technology innovator. | `Lisboa` |
 
 
 ## Travel :airplane:
 
 | Company | Description | Locations |
 | :------ | :---------- | :-------- |
-| [Hostelworld](https://www.hostelworld.com/) [:rocket:](http://www.hostelworldgroup.com/careers) | World's leading hostel-focused online booking platform. | `Porto` |
-| [Skyhour](https://skyhour.com/) [:rocket:](https://landing.jobs/at/skyhour) | Give and receive air travel. | `Lisboa` |
-| [TripAdvisor](https://www.tripadvisor.com) [:rocket:](https://careers.tripadvisor.com) | The largest "social travel website" in the world. | `Lisboa` |
+| [Hostelworld](https://www.hostelworld.com/) [:rocket:](http://www.hostelworldgroup.com/careers) [:speech_balloon:](https://pt.teamlyzer.com/companies/hostelworld-group) | World's leading hostel-focused online booking platform. | `Porto` |
+| [Skyhour](https://skyhour.com/) [:rocket:](https://landing.jobs/at/skyhour) [:speech_balloon:](https://pt.teamlyzer.com/companies/skyhour) | Give and receive air travel. | `Lisboa` |
+| [TripAdvisor](https://www.tripadvisor.com) [:rocket:](https://careers.tripadvisor.com) [:speech_balloon:](https://pt.teamlyzer.com/companies/tripadvisor) | The largest "social travel website" in the world. | `Lisboa` |


### PR DESCRIPTION
Add link for most companies with their teamlyzer url to check the company public feedback.