### PR TITLE
Added GitHub Links Possibility

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Please make sure the following company details are provided:
 * Name;
 * Website (linked from the company's name);
 * Careers website, if exists (linked from the :rocket:);
-* Github (or another git-repository manager) account, if exists (linked from the :octocat:);
+* Github (or another git-repository manager) account, if exists and contains at least one relevant, and considered active, repository (linked from the :octocat:);
 * Very short description;
 * List of portuguese locations (which may contain `Remote` if the company allows remote work).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Please make sure the following company details are provided:
 * Name;
 * Website (linked from the company's name);
 * Careers website, if exists (linked from the :rocket:);
-* Github (or another git-repository manager) account, if exists and contains at least one relevant, and considered active, repository (linked from the :octocat:);
+* Github account, or another git-repository manager account, if exists and contains at least one relevant and active repository (linked from the :octocat:);
 * Very short description;
 * List of portuguese locations (which may contain `Remote` if the company allows remote work).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,8 +7,14 @@ Please make sure the following company details are provided:
 * Name;
 * Website (linked from the company's name);
 * Careers website, if exists (linked from the :rocket:);
+* Github (or another git-repository manager) account, if exists (linked from the :octocat:);
 * Very short description;
 * List of portuguese locations (which may contain `Remote` if the company allows remote work).
+
+Below you can find an example of how to add a company:
+| Company | Description | Locations |
+| :------ | :---------- | :-------- |
+| [Example](https://example.com/) [:rocket:](https://www.example.com/careers) [:octocat:](https://www.github.com/example) | Example revolutionises the way people write examples. | `Example City` |
 
 Some additional things to keep in mind:
 * The company must allow working in/from Portugal;


### PR DESCRIPTION
Took the idea from @mmar in #203. Bonus: Added an Example company to `CONTRIBUTING.md`.

This way, going forward if a repository exists then it can be added, providing additional visibility to that company (which promotes open-source development).

What do you think?

Maybe having at least one open-source repository is also good one requirement.