### PR TITLE
Updated ZPX-> funcom ZPX

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Checking out the company's Tech stack through [Stackshare](https://stackshare.io
 | :------ | :---------- | :-------- |
 | [Fabamaq](https://www.fabamaq.com/) [:rocket:](https://www.fabamaq.com/pages.php?page_id=311) | Casino digital games. | `Porto` |
 | [Fun Punch Games](https://funpunchgames.com/) | Independent game development studio. | `Lisboa` |
-| [Funcom ZPX](https://www.funcom.com/) [:rocket:](https://www.funcom.com/careers-in-funcom/) | Full-range game development studio offering design, art, coding. | `Lisboa` |
+| [Funcom ZPX](https://www.funcom.com/) [:rocket:](https://www.funcom.com/funcom-zpx/) | Full-range game development studio offering design, art, coding. | `Lisboa` |
 | [Ground Control](http://www.gcontrolgames.com/) | Indie games/VR studio. | `Porto` |
 | [Miniclip](https://www.miniclip.com/) [:rocket:](https://corporate.miniclip.com/vacancies/) | Mobile and web game development company. | `Lisboa` |
 | [Not a Game Studio](http://www.notagamestudio.com/) | Game development studio focused on the experience of the users. | `Lisboa` |

--- a/README.md
+++ b/README.md
@@ -260,10 +260,10 @@ Checking out the company's Tech stack through [Stackshare](https://stackshare.io
 | :------ | :---------- | :-------- |
 | [Fabamaq](https://www.fabamaq.com/) [:rocket:](https://www.fabamaq.com/pages.php?page_id=311) | Casino digital games. | `Porto` |
 | [Fun Punch Games](https://funpunchgames.com/) | Independent game development studio. | `Lisboa` |
+| [Funcom ZPX](https://www.funcom.com/) [:rocket:](https://www.funcom.com/careers-in-funcom/) | Full-range game development studio offering design, art, coding. | `Lisboa` |
 | [Ground Control](http://www.gcontrolgames.com/) | Indie games/VR studio. | `Porto` |
 | [Miniclip](https://www.miniclip.com/) [:rocket:](https://corporate.miniclip.com/vacancies/) | Mobile and web game development company. | `Lisboa` |
 | [Not a Game Studio](http://www.notagamestudio.com/) | Game development studio focused on the experience of the users. | `Lisboa` |
-| [ZPX](https://www.zpx.pt/) [:rocket:](https://zpx.pt/careers.html) | Full-range game development studio offering design, art, coding. | `Lisboa` |
 
 
 ## Industry :factory:


### PR DESCRIPTION
It seems that ZPX got acquired by Funcom, making the studio name Funcom ZPX as seen [here](https://www.funcom.com/funcom-zpx/).