### PR TITLE
delete: oto.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,6 @@ Checking out the company's Tech stack through [Stackshare](https://stackshare.io
 | [Carrot](https://carrotincentives.com/) | ICM for Telco companies. | `Lisboa` |
 | [Celfocus](https://www.celfocus.com/) [:rocket:](https://careers.celfocus.com/) | Vodafone technology development. | `Lisboa` `Porto` |
 | [GoContact](https://www.gocontact.pt/) [:rocket:](https://www.gocontact.pt/recrutamento/) | Company specialized in integrated solutions for Contact Centers. | `Aveiro` `Lisboa` <br> `Porto`|
-| [Oto](https://www.oto.ai/) [:rocket:](https://www.oto.ai/company#Careers) | AI-powered Voice Intelligence for Call Centers. | `Lisboa` |
 | [Readiness IT](https://readinessit.com/) [:rocket:](https://readinessit.com/careers/) | Telecommunications technologies. | `Fundão` `Lisboa` <br> `Porto` `Remote` |
 | [Talkdesk](https://www.talkdesk.com) [:rocket:](https://www.talkdesk.com/careers/) | Enterprise cloud contact center. | `Aveiro` `Coimbra` <br> `Lisboa` `Porto` |
 | [WIT Software](https://www.wit-software.com) [:rocket:](https://www.wit-software.com/careers/) | Software development for telcom services (OTT, RCS, Mobile, Web & others). | `Aveiro` `Coimbra` <br> `Leiria` `Lisboa` <br>`Porto` |


### PR DESCRIPTION
It seems from [Oto's homepage](https://www.oto.ai/) that Oto has been [bought out by Unity](https://venturebeat.com/2021/08/24/unity-acquires-ai-chat-analysis-platform-oto-launches-toxicity-in-gaming-report/).

Browsing [Unity's career page](https://careers.unity.com/), it seems that they no longer have a Portuguese office.