### PR TITLE
add: Sibs & update: Multicert

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ Checking out the company's Tech stack through [Stackshare](https://stackshare.io
 | [Integrity](https://www.integrity.pt/) [:rocket:](https://www.integrity.pt/careers.html) | Consulting and tech audit focused on information Security. | `Lisboa` |
 | [JScrambler](https://jscrambler.com) [:rocket:](https://jscrambler.com/careers) | JavaScript application integrity and security. | `Porto` |
 | [Layer8](https://www.layer8.pt) | Consulting, technology and security managed services. | `Lisboa` |
-| [Multicert](https://www.multicert.com) [:rocket:](https://www.multicert.com/pt/sobre-nos/recrutamento/) | CA, enterprise security software products and consulting. | `Lisboa` `Porto` |
+| [Multicert](https://www.multicert.com) [:rocket:](https://sibs-sgps.zohorecruit.eu/careers) | CA, enterprise security software products and consulting. | `Lisboa` `Porto` |
 | [NCC Group](https://www.nccgroup.com/pt/) [:rocket:](https://www.nccgroupplc.com/careers/) | Global experts in cyber security and risk mitigation. | `Lisboa` `Remote` |
 | [Probely](https://probely.com) [:rocket:](https://careers.probely.com) | Automated web application security scanning as a service. | `Lisboa` |
 | [S21sec](https://www.s21sec.com) [:rocket:](https://www.s21sec.com/en/careers/) | Cybersecurity services. | `Lisboa` `Porto` |

--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Checking out the company's Tech stack through [Stackshare](https://stackshare.io
 | [Onfido](https://www.onfido.com) [:rocket:](https://onfido.com/jobs/) | Identity verification at the speed of life. | `Lisboa` |
 | [Revolut](https://www.revolut.com) [:rocket:](https://www.revolut.com/pt-PT/careers) | A digital banking alternative to conventional banks. | `Porto` |
 | [Seedrs](https://www.seedrs.com) [:rocket:](https://www.seedrs.com/careers) | Equity marketplace for everyone. | `Lisboa` |
+| [SIBS](https://www.sibs.com/) [:rocket:](https://sibs-sgps.zohorecruit.eu/careers) | Major Portuguese payment processor. | `Lisboa` |
 | [StudentFinance](https://studentfinance.com/) [:rocket:](https://jobs.studentfinance.com) | Disrupting education through Income Share Agreements | `Lisboa` `Remote` |
 | [Switch](https://switchpayments.com/) [:rocket:](https://switchpayments.com/about/careers) | The payments infrastructure for interoperability. | `Lisboa` `Porto` |
 | [Uphold](https://uphold.com/) [:rocket:](https://uphold.com/en/about-us/careers) | US cloud based financial services platform. | `Braga` |


### PR DESCRIPTION
From the [GitHub Action](https://github.com/marmelo/tech-companies-in-portugal/actions/runs/1724756129) it seems that Multicert's career page changed. 

The new "careers" URL is this one https://www.multicert.com/pt/carreiras/, however, inside it we can find the link to the true job listing page (which from my understanding should be the one linked), which redirects to the Sibs's career page (https://sibs-sgps.zohorecruit.eu/careers). Took advantage of this to also add SIBS.

Creating this as a draft PR since I'm not 100% sure if we should maintain both companies.