### PR TITLE
ci: add cronjob

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,6 +5,8 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  schedule:
+    - cron: "55 5 * * *"
 
 jobs:
   build:


### PR DESCRIPTION
If I'm not mistaken, the Travis CI workflow had a cron running. In this PR I am re-adding a cron job to run at 5h55 (random morning hour to avoid the midnight congestion) to avoid the constantly failing build due to the last build having happened days/weeks ago.