### PR TITLE
increase `awesome_bot` timeout

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,4 +25,4 @@ jobs:
         run: gem install awesome_bot
 
       - name: Check URLs
-        run: awesome_bot -f README.md --allow-ssl --allow-redirect --allow-dupe --allow 403,429 --set-timeout=5 --white-list linkedin.com,oracle.com,glandrive.pt,glintt.com
+        run: awesome_bot -f README.md --allow-ssl --allow-redirect --allow-dupe --allow 403,429 --set-timeout=10 --white-list linkedin.com,oracle.com,glandrive.pt,glintt.com


### PR DESCRIPTION
We are getting a lot of failed builds and, as such, we should increase the timeout to 10s to reduce their number. Take into account that the default for `awesome_bot` is 30s.