### PR TITLE
fixes fractal website

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ Checking out the company's Tech stack through [Stackshare](https://stackshare.io
 | [Feedzai](https://feedzai.com) [:rocket:](https://careers.feedzai.com) | Fraud detection platform to make commerce safe. | `Coimbra` `Lisboa` <br> `Porto` `Remote` |
 | [Fidel](https://fidel.uk) [:rocket:](https://fidel.uk/careers/) | One API for linking bank cards to digital applications, globally. | `Lisboa` |
 | [Finiam](https://www.finiam.com/) [:rocket:](https://www.finiam.com/#contact) | Improving people's lives by untangling the financial world. | `Braga` `Remote` |
-| [Fractal](https://company.fractal.id) | Enabling open finance with a new Internet Identity layer. | `Porto` `Remote` |
+| [Fractal](https://protocol.fractal.id) | Enabling open finance with a new Internet Identity layer. | `Porto` `Remote` |
 | [Iban Wallet](https://www.ibanwallet.com) | Invest in secured loans. | `Lisboa` |
 | [ITSector](https://www.itsector.pt/pt) [:rocket:](https://www.itsector.pt/pt/carreiras) | Software for financial institutions. | `Aveiro` `Braga` <br> `Bragança` `Lisboa` <br> `Porto` |
 | [JUMO](https://www.jumo.world) [:rocket:](https://www.jumo.world/careers) | Financial inclusion platform. | `Remote` |


### PR DESCRIPTION
Fixes Fractal website to new domain as referenced on their [twitter](https://twitter.com/fractalprtcl) and [linkedin](https://www.linkedin.com/company/fractalprotocol)