### PR TITLE
Remove Skyhour as it appears to have ended

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,5 +378,4 @@ Checking out the company's Tech stack through [Stackshare](https://stackshare.io
 | [eDreams ODIGEO](https://www.edreamsodigeo.com/) [:rocket:](https://www.edreamsodigeocareers.com) | We are shaping the way people travel today and tomorrow. | `Porto` |
 | [Hostelworld](https://www.hostelworld.com/) [:rocket:](https://www.hostelworldgroup.com/careers) | World's leading hostel-focused online booking platform. | `Porto` |
 | [Ryanair](https://www.ryanair.com/pt/pt) [:rocket:](https://careers.ryanair.com/search/#search/location=portugal&departments=ryanair-labs-portugal) | Ryanair is an Irish ultra low-cost carrier. | `Lisboa` `Porto`|
-| [Skyhour](https://skyhour.com/) [:rocket:](https://landing.jobs/at/skyhour) | Give and receive air travel. | `Lisboa` |
 | [TripAdvisor](https://www.tripadvisor.com) [:rocket:](https://careers.tripadvisor.com) | The largest "social travel website" in the world. | `Lisboa` |


### PR DESCRIPTION
Company site is not working for a few days and internet presence stopped.

* Crunchbase still states the company is open but seems like it's an empty shell https://www.crunchbase.com/organization
* Company domain is still registered but does point to any website
* No open positions https://landing.jobs/at/skyhour and according to linked only has 5 people now https://www.linkedin.com/company/skyhour/about/
* Dead social media sites https://pt-pt.facebook.com/skyhour/ https://twitter.com/skyhour

Original added on #90 