### PR TITLE
Improve link validation with lychee-action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: ".github/workflows"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,13 +24,14 @@ jobs:
           # --exclude-mail -> Ignore email links.
           # --no-progress -> Do not show progress bar in GH Action.
           # --accept 403 -> Tolerate 403 Forbidden because it's a common response for domains behind Cloudflare.
+          # --timeout 60 -> Have a bigger timeout due to some sites being slow sometimes.
           # --retry-wait-time 5 -> Retry failed links after 5 seconds to avoid some local throttling situations.
           # --exclude .*\.DOMAIN\.TEST/.* -> (Regex) Exclude all links to all DOMAIN.TEST subdomains
           #     does not match http://domain.test/best-jobs
           #     does match http://www.domain.test/best-jobs
           # --exclude .*\.linkedin\.com/.* -> Excluded because Linkedin just responds with 429 Too Many Requests.
           # --exclude .*\.faro\.com/.* -> Excluded because link check fails on GH Action but the reason is not known.
-          args: --verbose --exclude-all-private --exclude-mail --no-progress --accept 403 --retry-wait-time 5 --exclude .*\.linkedin\.com/.* --exclude .*\.faro\.com/.* -- README.md
+          args: --verbose --exclude-all-private --exclude-mail --no-progress --accept 403 --timeout 60 --retry-wait-time 5 --exclude .*\.linkedin\.com/.* --exclude .*\.faro\.com/.* -- README.md
           # Output more detail
           format: detailed
           # Fail action on broken links

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,20 +9,29 @@ on:
     - cron: "55 5 * * *"
 
 jobs:
-  build:
+  val-links:
     runs-on: ubuntu-latest
     timeout-minutes: 10
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Ruby 2.6
-        uses: actions/setup-ruby@v1
+      - name: Validate links
+        uses: lycheeverse/lychee-action@v1.4.1
         with:
-          ruby-version: 2.6.x
-
-      - name: Install dependencies
-        run: gem install awesome_bot
-
-      - name: Check URLs
-        run: awesome_bot -f README.md --allow-ssl --allow-redirect --allow-dupe --allow 403,429 --set-timeout=5 --white-list linkedin.com,oracle.com,glandrive.pt,glintt.com
+          # --verbose -> Include more detail for troubleshoot.
+          # --exclude-all-private -> Safeguard so avoid GH Action accessing runner local endpoints.
+          # --exclude-mail -> Ignore email links.
+          # --no-progress -> Do not show progress bar in GH Action.
+          # --accept 403 -> Tolerate 403 Forbidden because it's a common response for domains behind Cloudflare.
+          # --retry-wait-time 5 -> Retry failed links after 5 seconds to avoid some local throttling situations.
+          # --exclude .*\.DOMAIN\.TEST/.* -> (Regex) Exclude all links to all DOMAIN.TEST subdomains
+          #     does not match http://domain.test/best-jobs
+          #     does match http://www.domain.test/best-jobs
+          # --exclude .*\.linkedin\.com/.* -> Excluded because Linkedin just responds with 429 Too Many Requests.
+          # --exclude .*\.faro\.com/.* -> Excluded because link check fails on GH Action but the reason is not known.
+          args: --verbose --exclude-all-private --exclude-mail --no-progress --accept 403 --retry-wait-time 5 --exclude .*\.linkedin\.com/.* --exclude .*\.faro\.com/.* -- README.md
+          # Output more detail
+          format: detailed
+          # Fail action on broken links
+          fail: true


### PR DESCRIPTION
Replaced awesome-bot validation with lychee-action to improve stability and validation quality. You can notice that some links are incorrect and awesome-bot has not give us that feedback. (404 errors).

* lychee-action which uses lychee seems more stable and has retry features make it more suitable the GH Action
* lychee repo with nice comparison table https://github.com/lycheeverse/lychee#features
* lychee default retry is 3 which seems good enough.
* Added dependabot rule to get PRs with updates

Some limitations/issues/annoyances:
* When checking step output check the HTTP Status code between the square brackets since the error message is not that clear. Example: `✗ [404] https://www.symantec.com/about/careers | Network error: Not Found` means HTTP 404 Not Found
* Timeouts can mean a domain that does not exist. Example `⧖ [TIMEOUT] https://skyhour.com/ | Timeout` 
* GitHub Action UI parses some messages weirdly. This message `✗ [ERROR] http://www.alticelabs.com/ | Network error: No status code` is parsed by the UI and shows as ` Error: R] http://www.alticelabs.com/ | Network error: No status code`

This change can be updated to have both jobs running in parallel instead of just having one so this can be evaluated.
Tell what you guys think.