### PR TITLE
remove: symantec

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,6 @@ Checking out the company's Tech stack through [Stackshare](https://stackshare.io
 | [NCC Group](https://www.nccgroup.com/pt/) [:rocket:](https://www.nccgroupplc.com/careers/) | Global experts in cyber security and risk mitigation. | `Lisboa` `Remote` |
 | [Probely](https://probely.com) [:rocket:](https://careers.probely.com) | Automated web application security scanning as a service. | `Lisboa` |
 | [S21sec](https://www.s21sec.com) [:rocket:](https://www.s21sec.com/en/careers/) | Cybersecurity services. | `Lisboa` `Porto` |
-| [Symantec](https://www.symantec.com) [:rocket:](https://www.symantec.com/about/careers) | Enterprise and Consumer Security Products. | `Coimbra` `Remote` |
 
 
 ## Social :couple:


### PR DESCRIPTION
It seems that [Symantec is now redirecting to Broadcom's website](https://www.symantec.com/), and, additionally, there are no references to any Portugal office in [Broadcom's career page](https://broadcom.wd1.myworkdayjobs.com/External_Career).