### PR TITLE
Remove cloudmobility.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ Checking out the company's Tech stack through [Stackshare](https://stackshare.io
 | :------ | :---------- | :-------- |
 | [AddVolt](https://addvolt.com/) [:rocket:](https://www.addvolt.com/en/#Contacts) | AddVolt's platform reduces CO2 in the heavy transportation sector. | `Porto` |
 | [Bosch](https://www.bosch.pt/) [:rocket:](https://www.bosch.pt/carreiras/) | German engineering and technology company with a big focus on the automotive industry. | `Aveiro` `Braga` <br> `Ovar` |
-| [Cloudmobility](https://cloudmobility.io/) [:rocket:](https://cloudmobility.io/career) | Special purpose cloud for mobility and transportation. | `Lisboa` |
 | [Critical TechWorks](https://www.criticaltechworks.com/) [:rocket:](https://www.criticaltechworks.com/#openroll) | Developing next generation software systems for BMW. | `Lisboa` `Porto` |
 | [Flow](https://gowithflow.io/) [:rocket:](https://gowithflow.recruitee.com/) | Data powered fleet electrification. | `Leça da Palmeira` |
 | [Mercedes-Benz.io](https://www.mercedes-benz.io) [:rocket:](https://www.mercedes-benz.io/jobs) | Shaping the digital future of Mercedes-Benz. | `Lisboa` |


### PR DESCRIPTION
* Current site just redirects to mercedes-benz.com
* Cloudmobility company was just sub-organization at Mercedes-Benz.io «This is where Mercedes Benz, as the pioneer in the automobile industry, comes in as cloudmobility's root.» reference http://web.archive.org/web/20200710055454/http://cloudmobility.io/about-us/index.html
* Mercedes-Benz.io already listed
* Linkedin company page has been nuked https://www.linkedin.com/company/cloudmobility

Funny enough old site seems to up at https://34.107.187.75/about-us/