### PR TITLE
fix: truphone and m-profiler

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [master]
   schedule:
-    - cron: "55 5 * * *"
+    - cron: '55 5 * * *'
 
 jobs:
   val-links:
@@ -32,8 +32,10 @@ jobs:
           # --exclude .*\.linkedin\.com/.* -> Excluded because Linkedin just responds with 429 Too Many Requests.
           # --exclude .*\.faro\.com/.* -> Excluded because link check fails on GH Action but the reason is not known.
           # --exclude .*\.humanprofiler\.com/.* -> lychee states "Network error: No status code" but URLs are OK even if slow
+          # --exclude .*\.m-profiler\.com/.* -> lychee states "Network error: No status code" but URLs are OK even if slow
+          # --exclude .*\.web.truphone.com/careers.* -> lychee states "Network error: No status code" for careers website but URL is OK
           # --exclude .*\.blissapplications\.com/.* -> Site is extremly slow taking some times 2 minutes to respond
-          args: --verbose --exclude-all-private --exclude-mail --no-progress --accept 403 --timeout 65 --retry-wait-time 5 --exclude .*\.linkedin\.com/.* --exclude .*\.faro\.com/.* --exclude .*\.humanprofiler\.com/.* --exclude .*\.blissapplications\.com/.* -- README.md
+          args: --verbose --exclude-all-private --exclude-mail --no-progress --accept 403 --timeout 65 --retry-wait-time 5 --exclude .*\.linkedin\.com/.* --exclude .*\.faro\.com/.* --exclude .*\.humanprofiler\.com/.* --exclude .*\.m-profiler\.com/.* --exclude .*\.web.truphone.com/.* --exclude .*\.blissapplications\.com/.* -- README.md
           # Output more detail
           format: detailed
           # Fail action on broken links

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: ['*']
   pull_request:
     branches: [master]
   schedule:

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ Checking out the company's Tech stack through [Stackshare](https://stackshare.io
 | [Readiness IT](https://readinessit.com/) [:rocket:](https://readinessit.com/careers/) | Telecommunications technologies. | `Fundão` `Lisboa` <br> `Porto` `Remote` |
 | [Talkdesk](https://www.talkdesk.com) [:rocket:](https://www.talkdesk.com/careers/) | Enterprise cloud contact center. | `Aveiro` `Coimbra` <br> `Lisboa` `Porto` |
 | [WIT Software](https://www.wit-software.com) [:rocket:](https://www.wit-software.com/careers/) | Software development for telcom services (OTT, RCS, Mobile, Web & others). | `Aveiro` `Coimbra` <br> `Leiria` `Lisboa` <br>`Porto` |
-| [Truphone](https://www.truphone.com) [:rocket:](https://www.truphone.com/careers/) | Global mobile connectivity and eSIM technology innovator. | `Lisboa` |
+| [Truphone](https://www.truphone.com) [:rocket:](https://web.truphone.com/careers/) | Global mobile connectivity and eSIM technology innovator. | `Lisboa` |
 
 
 ## Travel :airplane:


### PR DESCRIPTION
truphone and m-profiler have been failing for quite some time, so I have added them to the exclusions since their website works although slow. Also enabled the possibility of running the action on push since I saw no real reason not to have it on a public repo.

Note: Abyssal was temporarily giving a 502, which triggered the failed push build.