### PR TITLE
Change link checker to ignore TLS errors

### DIFF
--- a/.github/workflows/.lycheeignore
+++ b/.github/workflows/.lycheeignore
@@ -15,11 +15,3 @@
 # Excluded because an error is consistently generated but the URLs are OK.
 # Error seen: Network error: error following redirect for url too many redirects
 .*\.faro\.com/.*
-# Excluded because the webserver is badly configured and URLs have manually checked before.
-# Server is incorrectly configured and not serving the intermediate CA, ref https://news.ycombinator.com/item?id=31430969
-# Error seen: Network error: certificate verify failed (unable to get local issuer certificate)
-.*\.humanprofiler\.com/.*
-.*\.m-profiler\.com/.*
-web.truphone.com/.*
-multivision\.pt/.*
-emealjobs\.nttdata\.com/.*

--- a/.github/workflows/lychee.toml
+++ b/.github/workflows/lychee.toml
@@ -17,6 +17,9 @@ retry_wait_time = 5
 # Tolerate HTTP 403 Forbidden responses because it's a common response for domains behind Cloudflare.
 accept = [403]
 
+# Tolerate certificate issues since several sites have certificate chain issues :(
+insecure = true
+
 ####   Exclusions   ###############################
 
 # Safeguard so avoid GH Action accessing runner local endpoints

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Checking out the company's Tech stack through [Stackshare](https://stackshare.io
 | [Aubay](https://www.aubay.pt/) [:rocket:](https://www.aubay.pt/Home/Opportunities) | Consultancy, Outsourcing, and Nearshore projects. | `Lisboa` `Porto` |
 | [Bee Engineering](https://www.bee-eng.pt/pt/) [:rocket:](https://www.bee-eng.pt/pt/carreira/) | Consultancy, Outsourcing. | `Lisboa` `Porto` |
 | [BOLD by Devoteam](https://bold.devoteam.com/) [:rocket:](https://bold.devoteam.com/join-us/) | Consultancy, Outsourcing. | `Aveiro` `Lisboa` <br> `Porto` |
-| [Damia](https://www.damiagroup.pt/) [:rocket:](https://www.damiagroup.pt/job/) | Human 2 Human Tech Recruitment. | `Aveiro` `Lisboa` <br> `Porto` |
+| [Damia](https://www.damiagroup.pt/) [:rocket:](https://www.damiagroup.pt/careers/) | Human 2 Human Tech Recruitment. | `Aveiro` `Lisboa` <br> `Porto` |
 | [Dellent Consulting](https://dellentconsulting.com/) [:rocket:](https://dellentconsulting.com/_carreiras/) | Consultancy, Outsourcing. | `Aveiro` `Lisboa` |
 | [Everis](https://www.everis.com/portugal/pt-pt/home-pt) | Consultancy, Outsourcing. | `Lisboa` |
 | [GLanDrive](https://www.glandrive.pt) | Consultancy, Outsourcing. | `Lisboa` `Porto` |
@@ -118,7 +118,7 @@ Checking out the company's Tech stack through [Stackshare](https://stackshare.io
 | [Integer Consulting](https://integerconsulting.pt/) [:rocket:](https://integerconsulting.pt/opportunity/) | Consultancy, Outsourcing and Nearshore | `Lisboa` `Porto` |
 | [KCSIT](https://kcsit.pt/) [:rocket:](https://kcsit.pt/carreiras/) | Consultancy, Outsourcing. | `Lisboa` `Porto` |
 | [Match Profiler](https://www.m-profiler.com/) [:rocket:](https://www.m-profiler.com/carreiras) | Consultancy, Outsourcing. | `Lisboa` |
-| [HumanProfiler](https://www.humanprofiler.com) [:rocket:](https://www.humanprofiler.com/ultimas-ofertas-de-emprego) | Consultancy, Outsourcing. | `Lisboa` |
+| [HumanProfiler](https://www.humanprofiler.com) [:rocket:](https://www.humanprofiler.com/ofertas-de-emprego) | Consultancy, Outsourcing. | `Lisboa` |
 | [KWAN](https://www.kwan.pt/) | Consultancy, Outsourcing. | `Lisboa` `Porto` |
 | [Landing.jobs](https://landing.jobs) [:rocket:](https://landing.jobs/at/landing-jobs) | Helping people find the right fit tech job. | `Lisboa` |
 | [Multivision](https://multivision.pt) [:rocket:](https://www.linkedin.com/company/multivision---consultoria-em-telecomunica-es-e-inform-tica-lda-/jobs/) | Consultancy, Outsourcing. | `Lisboa` |


### PR DESCRIPTION
The noise of the TLS/certificate chain errors is high and just realized that not testing a link because of it actually makes it worse,  then we will never know when a 404 Not Found happens.

- Removal all exclusions due to the certificate chain issues
- Fix Damia and HumanProfiler careers links