### PR TITLE
Remove Avenue

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,3 @@ Checking out the company's Tech stack through [Stackshare](https://stackshare.io
 | [Ryanair](https://www.ryanair.com/pt/pt) [:rocket:](https://careers.ryanair.com/search/#search/location=portugal&departments=ryanair-labs-portugal) | Ryanair is an Irish ultra low-cost carrier. | `Lisboa` `Porto`|
 | [TripAdvisor](https://www.tripadvisor.com) [:rocket:](https://careers.tripadvisor.com) | The largest "social travel website" in the world. | `Lisboa` |
 
-## Web3 :spider_web:
-| Company | Description | Locations |
-| :------ | :---------- | :-------- |
-| [Avenue](https://avenue.place) [:rocket:](https://careers.avenue.place) | A communications and collaboration platform for DAOs. | `Porto` `Remote` |


### PR DESCRIPTION
Was given a 404 in the pipeline, confirmed to have ceased.

- Twitter post https://nitter.net/avenueplace/status/1669718205512777730#m (twitter clone that allows me to share a link)
- Official account confirmed from the site http://web.archive.org/web/20230602192210/https://avenue.place/