### PR TITLE
update: esl face it group

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,8 +298,8 @@ Checking out the company's Tech stack through [Stackshare](https://stackshare.io
 
 | Company | Description | Locations |
 | :------ | :---------- | :-------- |
+| [ESL FACEIT GROUP](https://eslfaceitgroup.com/) [:rocket:](https://eslfaceitgroup.com/career/)| E-Sports and social platform. | `Remote` |
 | [Fabamaq](https://www.fabamaq.com/) [:rocket:](https://www.fabamaq.com/pages.php?page_id=311) | Casino digital games. | `Porto` |
-| [FACEIT](https://www.faceit.com/) [:rocket:](https://corporate.faceit.com/available-jobs/)| E-Sports and social platform. | `Remote` |
 | [Fun Punch Games](https://funpunchgames.com/) | Independent game development studio. | `Lisboa` |
 | [Funcom ZPX](https://www.funcom.com/) [:rocket:](https://www.funcom.com/funcom-zpx/) | Full-range game development studio offering design, art, coding. | `Lisboa` |
 | [Ground Control](https://www.gcontrolgames.com/) | Indie games/VR studio. | `Porto` |


### PR DESCRIPTION
Page started giving a 404, and it seems that it is because [they have merged the two companies](https://en.wikipedia.org/wiki/ESL_(company)).

> In 2022, it was announced that ESL and esports platform [FACEIT](https://en.wikipedia.org/wiki/FACEIT) were acquired by [Savvy Games Group](https://en.wikipedia.org/wiki/Savvy_Games_Group) (SGG), a holding company owned by [Saudi Arabia](https://en.wikipedia.org/wiki/Saudi_Arabia)'s [Public Investment Fund](https://en.wikipedia.org/wiki/Public_Investment_Fund). As part of the acquisition, the two companies merged to form the ESL FACEIT Group.[[5]](https://en.wikipedia.org/wiki/ESL_(company)#cite_note-:0-5)[[6]](https://en.wikipedia.org/wiki/ESL_(company)#cite_note-:1-6)