### PR TITLE
fix: rename novabase to neotalent

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ Checking out the company's Tech stack through [Stackshare](https://stackshare.io
 | [IT People](https://itpeople.pt) [:rocket:](https://itpeople.pt/speak-to-us/) | Outsourcing & Nearshore Development. | `Covilhã` `Lisboa` <br> `Porto`|
 | [Mindera](https://mindera.com) [:rocket:](https://mindera.com/#we-are-hiring) | Technology development and consultancy. | `Aveiro` `Coimbra` <br> `Porto` |
 | [Moxy](https://moxy.studio) [:rocket:](https://moxy.studio/team#join-the-team) | Interdisciplinary studio focused on design and development. | `Porto` |
+| [Neotalent](https://neotalent.pt/) [:rocket:](https://neotalent.pt/en/careers/job-opportunities/) | IT recruitment and talent management specialists. | `Lisboa` `Porto` |
 | [Noesis](https://www.noesis.pt) [:rocket:](https://opportunities.noesis.pt/jobs) | Consultancy and enterprise software. | `Coimbra` `Covilhã` <br> `Guarda` `Lisboa` <br> `Porto` |
-| [Novabase](https://www.novabase.com) [:rocket:](https://www.novabase.com/en/candidates/opportunities/) | Simpler & happier. | `Lisboa` |
 | [NTT DATA](https://pt.nttdata.com/) [:rocket:](https://emealjobs.nttdata.com/pt-pt/ofertas-portugal) | The 6th IT services company in the world. | `Lisboa` `Remote` |
 | [Opensoft](https://www.opensoft.pt/) [:rocket:](https://www.opensoft.pt/carreiras/) | Making life easier. | `Lisboa` |
 | [Premium Minds](https://www.premium-minds.com/) [:rocket:](https://join.premium-minds.com/) | We build great software for innovative clients. | `Lisboa` |


### PR DESCRIPTION
It seems that Novabase is doing some restructuring and selling its "main" IT business: https://www.linkedin.com/posts/novabase_a-novabase-acaba-de-divulgar-ao-mercado-a-activity-7118339267264692224-rtVP

They have killed the job opportunities from their main site as well.