### PR TITLE
Remove Everis

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,6 @@ Checking the company's Tech stack through [Stackshare](https://stackshare.io/) m
 | [BOLD by Devoteam](https://bold.devoteam.com/) [:rocket:](https://bold.devoteam.com/join-us/) | Consultancy, Outsourcing. | `Aveiro` `Lisboa` <br> `Porto` |
 | [Damia](https://www.damiagroup.pt/) [:rocket:](https://www.damiagroup.pt/careers/) | Human 2 Human Tech Recruitment. | `Aveiro` `Lisboa` <br> `Porto` |
 | [Dellent Consulting](https://dellentconsulting.com/) [:rocket:](https://dellentconsulting.com/_carreiras/) | Consultancy, Outsourcing. | `Aveiro` `Lisboa` |
-| [Everis](https://www.everis.com/portugal/pt-pt/home-pt) | Consultancy, Outsourcing. | `Lisboa` |
 | [Inoweiser](https://www.inoweiser.com/) [:rocket:](https://www.inoweiser.com/careers) | Consultancy | `Lisboa` |
 | [Integer Consulting](https://integerconsulting.pt/) [:rocket:](https://integerconsulting.pt/opportunity/) | Consultancy, Outsourcing and Nearshore | `Lisboa` `Porto` |
 | [KCSIT](https://kcsit.pt/) [:rocket:](https://kcsit.pt/carreiras/) | Consultancy, Outsourcing. | `Lisboa` `Porto` |


### PR DESCRIPTION
Remove Everis
- Site is dead
- Was acquired a while ago by NTT DATA which is already listed
- Brand was dropped https://exame.com/tecnologia/a-everis-agora-e-ntt-data-e-apresenta-ao-publico-a-nova-nuvem/ https://revolutions4.nttdata.com/en/ntt-data-accelerates-its-integration-process-with-tts-performance-suite/