### PR TITLE
Add UbiRider to Mobility section

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@ Checking the company's Tech stack through [Stackshare](https://stackshare.io/) m
 | :------ | :---------- | :-------- |
 | [FAIRTIQ](https://fairtiq.com/en/) [:rocket:](https://fairtiq.com/en/careers) | Public transport electronic tickets | `Remote` |
 | [Stratio](https://stratioautomotive.com/) [:rocket:](https://careers.stratioautomotive.com/) | Predictive fleet maintenance platform | `Lisboa` `Coimbra` `Remote` |
+| [UbiRider](https://ubirider.com/) | Digital platform to serve transport providers and travellers | `Porto` `Remote` |
 
 ## Multimedia :movie_camera:
 


### PR DESCRIPTION
Hello,

This merge request adds [UbiRider](https://www.ubirider.com/), a digital platform for urban mobility for providers and end users, to the Mobility section.