### PR TITLE
Fix/ci20250130

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Checking the company's Tech stack through [Stackshare](https://stackshare.io/) m
 | [Aptoide](https://www.aptoide.com/) [:rocket:](https://pt.aptoide.com/company/jobs) | Your Android app store. | `Lisboa` |
 | [Barkyn](https://barkyn.com/) [:rocket:](https://barkyn.factorialhr.pt/) | Barkyn delivers health and happiness to pet families around the world. | `Porto` |
 | [Blip](https://blip.pt) [:rocket:](https://blip.pt/jobs/) | Online betting and gambling operator. | `Porto` |
-| [Farfetch](https://www.farfetch.com) [:rocket:](https://farfetchgroupcareers.com/jobs) | Global technology platform for luxury fashion. | `Braga` `Lisboa` <br> `Porto` |
+| [Farfetch](https://www.farfetch.com) [:rocket:](https://aboutfarfetch.com/careers/our-approach-to-hiring/ | Global technology platform for luxury fashion. | `Braga` `Lisboa` <br> `Porto` |
 | [Jumia](https://group.jumia.com) [:rocket:](https://group.jumia.com/careers) | Online Shopping for Electronics, Phones & Fashion in Africa. | `Porto` |
 | [Jumpseller](https://jumpseller.com) [:rocket:](https://jumpseller.com/jobs) | E-commerce platform to create online stores. | `Porto` |
 | [Kaizen Gaming](https://kaizengaming.com) [:rocket:](https://careers.kaizengaming.com) | Online betting and gambling operator. | `Lisboa` |

--- a/README.md
+++ b/README.md
@@ -397,7 +397,6 @@ Checking the company's Tech stack through [Stackshare](https://stackshare.io/) m
 
 | Company | Description | Locations |
 | :------ | :---------- | :-------- |
-| [Adamant Sec](https://adamantsec.com/) | Pentesting, consulting and audit. | `Porto` |
 | [Barracuda Networks](https://www.barracuda.com/) [:rocket:](https://www.barracuda.com/company/careers) | Builds Security, Networking and Storage products. | `Porto` <br> `Remote` |
 | [Bitsight](https://www.bitsight.com/) [:rocket:](https://www.bitsight.com/about/careers) | The Global Leader In Security Ratings. | `Lisboa` `Remote` |
 | [Blaze Information Security](https://www.blazeinfosec.com/) | Pentesting, consulting and research. | `Porto` |

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Checking the company's Tech stack through [Stackshare](https://stackshare.io/) m
 | [Landskill](https://www.landskill.com) [:rocket:](https://www.landskill.com/careers/) | Performance-focused IT consultancy. | `Lisboa` |
 | [Link Consulting](https://www.linkconsulting.com/) [:rocket:](https://www.linkconsulting.com/its-fun-to-work-at-link/) | Global Tech, Consultancy, Services and Innovation. | `Leiria` `Lisboa` <br> `Porto` `Remote` |
 | [LIS @ IPN](https://www.ipn.pt/laboratorio/LIS) | Technological R&D and innovative multi-disciplinary projects. | `Coimbra` |
-| [LTPLabs](https://ltplabs.com/) [:rocket:](https://ltplabs.com/jobs/) | Boutique analytical-driven management consultancy company. | `Porto` `Lisboa` |
+| [LTPLabs](https://ltplabs.com/) | Boutique analytical-driven management consultancy company. | `Porto` `Lisboa` |
 | [KI labs](https://ki-labs.com/) [:rocket:](https://ki-labs.com/careers/) | Solve complex tech and business challenges for big corporations. | `Lisboa` |
 | [InnoWave](https://innowave.tech/) [:rocket:](https://innowave.tech/careers/) | Global technology and consulting company. | `Coimbra` `Lisboa`|
 | [IT People](https://itpeople.pt) [:rocket:](https://itpeople.pt/speak-to-us/) | Outsourcing & Nearshore Development. | `Covilhã` `Lisboa` <br> `Porto`|


### PR DESCRIPTION
- Fix LTPLabs
  - Removed careers links, causing a HTTP 404, current site does seem to have a careers page.
- Fix Adamant Sec
  - Removed as site is dead and company was dissolved in 2022, NIF 514578130 , check https://publicacoes.mj.pt/Pesquisa.aspx
- Fix Farfetch
  - Careers site has been changed