### PR TITLE
Renaming Alter Solutions to act digital

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ Checking the company's Tech stack through [Stackshare](https://stackshare.io/) m
 
 | Company | Description | Locations |
 | :------ | :---------- | :-------- |
+| [act digital](https://www.alter-solutions.pt) [:rocket:](https://www.alter-solutions.pt/oportunidades-emprego) | Consultancy, Outsourcing, and Nearshore projects. | `Lisboa` `Porto` |
 | [Affinity](https://affinity.pt) [:rocket:](https://affinity.pt/en/careers/) | Consultancy, Outsourcing. | `Lisboa` `Porto` |
 | [AGAP2](https://www.agap2-it.pt) [:rocket:](https://www.agap2-it.pt) | Consultancy, Outsourcing. | `Lisboa` `Porto` |
-| [Alter Solutions](https://www.alter-solutions.com/) [:rocket:](https://www.alter-solutions.com/join-us) | Consultancy, Outsourcing, and Nearshore projects. | `Lisboa` `Porto` |
 | [Ankix](https://www.ankix.com/) [:rocket:](https://www.ankix.com/it-job-offers) | Consultancy, Outsourcing. | `Lisboa` |
 | [Aubay](https://www.aubay.pt/) [:rocket:](https://www.aubay.pt/talento) | Consultancy, Outsourcing, and Nearshore projects. | `Lisboa` `Porto` |
 | [Bee Engineering](https://www.bee-eng.pt/) [:rocket:](https://www.bee-eng.pt/lista-empregos) | Consultancy, Outsourcing. | `Lisboa` `Porto` |


### PR DESCRIPTION
With the recent acquisition from Alter Solutions by act digital, the company was renamed to match the new group denomination.

The new domain is still under development, reason why it was not updated along the listing.

The name in lowercase "act digital" is according to the branding choice, so I'm proposing the name as is on this PR to reflect that decision. Please let me know if this is OK or another style is preferred to match the existing entries.

The entry was re-sorted to match the alphabetical order.