### PR TITLE
Add companies

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Checking the company's Tech stack through [Stackshare](https://stackshare.io/) m
 | Company | Description | Locations |
 | :------ | :---------- | :-------- |
 | [Codacy](https://www.codacy.com) [:rocket:](https://www.codacy.com/careers) [:octocat:](https://github.com/codacy) | Automated code reviews & code analytics. | `Lisboa` `Remote` |
-| [Dash0](https://www.dash0.com/) [:rocket:](https://careers.dash0.com/) [:octocat:](https://github.com/dash0hq) | Collaborative API observability platform for debugging and monitoring APIs. | `Remote` |
+| [Dash0](https://www.dash0.com/) [:rocket:](https://careers.dash0.com/) [:octocat:](https://github.com/dash0hq) | Observability platform. | `Remote` |
 | [Datadog](https://www.datadog.com) [:rocket:](https://careers.datadoghq.com/) [:octocat:](https://github.com/datadog) | Cloud monitoring as a service | `Lisboa` `Remote` |
 | [Docker](https://docker.com) [:rocket:](https://www.docker.com/careers/) [:octocat:](https://github.com/docker) | Container and k8s tooling for developers. | `Remote` |
 | [Elastic](https://jobs.elastic.co/) [:rocket:](https://jobs.elastic.co/)  [:octocat:](https://github.com/elastic) | Search, observability, and security platform powering data insights. | `Remote` |
@@ -299,7 +299,7 @@ Checking the company's Tech stack through [Stackshare](https://stackshare.io/) m
 | [Veeam](https://www.veeam.com/) [:rocket:](https://careers.veeam.com/vacancies) | Backup, recovery, and data management solutions for businesses. | `Lisboa` |
 | [VOID Software](https://www.void.pt/) | Systems design & architecture using different technology stacks. | `Leiria` |
 | [Visor.ai](https://www.visor.ai) [:rocket:](https://careers.visor.ai) | No-code platform that automates customer service using AI. | `Lisboa` `Remote` |
-| [Workato](https://www.workato.com/) [:rocket:](https://www.workato.com/careers) | Enterprise automation platform for app integration and workflow orchestration. | `Lisboa` `Porto` |
+| [Workato](https://www.workato.com/) [:rocket:](https://www.workato.com/careers) | Automation platform for app integration and workflow orchestration. | `Lisboa` `Porto` |
 | [Workia](https://workia.com/en/) | Simplifies the management of global employee mobility programs. | `Lisboa` |
 
 

--- a/README.md
+++ b/README.md
@@ -449,7 +449,6 @@ Checking the company's Tech stack through [Stackshare](https://stackshare.io/) m
 | [Layer8](https://www.layer8.pt) | Consulting, technology, and security managed services. | `Lisboa` |
 | [Multicert](https://www.multicert.com) [:rocket:](https://sibs-sgps.zohorecruit.eu/careers) | CA, enterprise security software products and consulting. | `Lisboa` `Porto` |
 | [NCC Group](https://www.nccgroup.com/pt/) [:rocket:](https://www.nccgroupplc.com/careers/) | Global experts in cyber security and risk mitigation. | `Lisboa` `Remote` |
-| [Probely](https://probely.com) [:rocket:](https://careers.probely.com) | Automated web application security scanning as a service. | `Lisboa` |
 | [S21sec](https://www.s21sec.com/) [:rocket:](https://www.s21sec.com/join-us/) | Cybersecurity services. | `Lisboa` `Porto` |
 | [Snyk](https://snyk.io/) [:rocket:](https://snyk.io/careers/) [:octocat:](https://github.com/snyk) | Helps developers find and fix security vulnerabilities in code. | `Lisboa` |
 | [Vawlt](https://vawlt.io) [:rocket:](https://vawlt.io/company/careers) | Cloud-based data security and encryption solutions | `Lisboa` `Remote` |

--- a/README.md
+++ b/README.md
@@ -179,8 +179,10 @@ Checking the company's Tech stack through [Stackshare](https://stackshare.io/) m
 | Company | Description | Locations |
 | :------ | :---------- | :-------- |
 | [Codacy](https://www.codacy.com) [:rocket:](https://www.codacy.com/careers) [:octocat:](https://github.com/codacy) | Automated code reviews & code analytics. | `Lisboa` `Remote` |
+| [Dash0](https://www.dash0.com/) [:rocket:](https://careers.dash0.com/) [:octocat:](https://github.com/dash0hq) | Collaborative API observability platform for debugging and monitoring APIs. | `Remote` |
 | [Datadog](https://www.datadog.com) [:rocket:](https://careers.datadoghq.com/) [:octocat:](https://github.com/datadog) | Cloud monitoring as a service | `Lisboa` `Remote` |
 | [Docker](https://docker.com) [:rocket:](https://www.docker.com/careers/) [:octocat:](https://github.com/docker) | Container and k8s tooling for developers. | `Remote` |
+| [Elastic](https://jobs.elastic.co/) [:rocket:](https://jobs.elastic.co/)  [:octocat:](https://github.com/elastic) | Search, observability, and security platform powering data insights. | `Remote` |
 | [Gitlab](https://about.gitlab.com/) [:rocket:](https://about.gitlab.com/jobs/all-jobs/) | DevOps platform for source code management, CI/CD, and collaboration. | `Remote` |
 | [Hugging Face](https://huggingface.co/) [:rocket:](https://apply.workable.com/huggingface/) [:octocat:](https://github.com/huggingface) | AI company specializing in natural language processing tools. | `Remote` |
 | [Nitro](https://www.gonitro.com/) [:rocket:](https://www.gonitro.com/about/careers) | Productivity platform that simplifies PDF editing and collaboration. | `Porto` |
@@ -297,6 +299,7 @@ Checking the company's Tech stack through [Stackshare](https://stackshare.io/) m
 | [Veeam](https://www.veeam.com/) [:rocket:](https://careers.veeam.com/vacancies) | Backup, recovery, and data management solutions for businesses. | `Lisboa` |
 | [VOID Software](https://www.void.pt/) | Systems design & architecture using different technology stacks. | `Leiria` |
 | [Visor.ai](https://www.visor.ai) [:rocket:](https://careers.visor.ai) | No-code platform that automates customer service using AI. | `Lisboa` `Remote` |
+| [Workato](https://www.workato.com/) [:rocket:](https://www.workato.com/careers) | Enterprise automation platform for app integration and workflow orchestration. | `Lisboa` `Porto` |
 | [Workia](https://workia.com/en/) | Simplifies the management of global employee mobility programs. | `Lisboa` |
 
 


### PR DESCRIPTION
Add

- Elastic (Hiring in Portugal. See [here](https://jobs.elastic.co/jobs/engineering/canada/elasticsearch-senior-java-developer-distributed-systems/7130129?gh_jid=7130129))
- Workato (Hiring in Lisboa and Porto. See [here](https://job-boards.greenhouse.io/workato/jobs/8076556002))
- Dash0 (Hiring in Europe. See [here](https://careers.dash0.com/senior-product-engineer-backend/en))

Remove

- Probely: Acquired by Snyk last year ([source](https://www.bankinfosecurity.com/embargo-1112-8am-et-snyk-acquires-probely-to-strengthen-api-security-for-ai-a-26787))