### PR TITLE
Add Digital Loyalty Card to Enterprise Software

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ Checking the company's Tech stack through [Stackshare](https://stackshare.io/) m
 | [CSG](https://www.csgi.com/) [:rocket:](https://www.csgi.com/careers/) | Cloud-native Business Support System platform. | `Remote` |
 | [Deel](https://www.deel.com/) [:rocket:](https://jobs.ashbyhq.com/Deel?departmentId=8c27e7fa-f898-4de1-adf6-70c67c1e1c11&locationId=7a1f038b-147a-4a65-8ba5-d047fda72a10) [:octocat:](https://github.com/letsdeel) | Compliance, payroll, HR, and performance for any worker globally in a single SaaS platform. | `Remote` |
 | [Deimos](https://deimos-space.com/) [:rocket:](https://deimos-space.com/jobs/) | Advanced design solutions and turn-key space software systems. | `Lisboa` |
+| [Digital Loyalty Card](https://digitalloyaltycard.io/) | Digital loyalty platform for local businesses with branded stamp cards on Apple and Google Wallets. | `Remote` |
 | [Dremio](https://www.dremio.com/) [:rocket:](https://www.dremio.com/careers/job-postings/) | Data as a service platform for fast analytics and data integration. | `Lisboa` `Remote` |
 | [Dual Entry](https://www.dualentry.com/) [:rocket:](https://careers.dualentry.com/) | AI-native accounting software for high-growth enterprises. | `Remote` |
 | [epilot](https://www.epilot.cloud/) [:rocket:](https://epilot.cloud/en/career-jobs/engineering/) [:octocat:](https://github.com/epilot-dev) | B2B e-commerce software for complex energy products. | `Remote` |

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ Checking the company's Tech stack through [Stackshare](https://stackshare.io/) m
 | [CSG](https://www.csgi.com/) [:rocket:](https://www.csgi.com/careers/) | Cloud-native Business Support System platform. | `Remote` |
 | [Deel](https://www.deel.com/) [:rocket:](https://jobs.ashbyhq.com/Deel?departmentId=8c27e7fa-f898-4de1-adf6-70c67c1e1c11&locationId=7a1f038b-147a-4a65-8ba5-d047fda72a10) [:octocat:](https://github.com/letsdeel) | Compliance, payroll, HR, and performance for any worker globally in a single SaaS platform. | `Remote` |
 | [Deimos](https://deimos-space.com/) [:rocket:](https://deimos-space.com/jobs/) | Advanced design solutions and turn-key space software systems. | `Lisboa` |
-| [Digital Loyalty Card](https://digitalloyaltycard.io/) | Digital loyalty platform for local businesses with branded stamp cards on Apple and Google Wallets. | `Remote` |
+| [Digital Loyalty Card](https://digitalloyaltycard.io/) | Digital loyalty platform for local businesses with branded stamp cards on Apple and Google Wallets. | `Lisboa` |
 | [Dremio](https://www.dremio.com/) [:rocket:](https://www.dremio.com/careers/job-postings/) | Data as a service platform for fast analytics and data integration. | `Lisboa` `Remote` |
 | [Dual Entry](https://www.dualentry.com/) [:rocket:](https://careers.dualentry.com/) | AI-native accounting software for high-growth enterprises. | `Remote` |
 | [epilot](https://www.epilot.cloud/) [:rocket:](https://epilot.cloud/en/career-jobs/engineering/) [:octocat:](https://github.com/epilot-dev) | B2B e-commerce software for complex energy products. | `Remote` |


### PR DESCRIPTION
## Summary

- Adds [Digital Loyalty Card](https://digitalloyaltycard.io/) to the **Enterprise Software** section
- Placed in alphabetical order between Deimos and Dremio
- Digital loyalty platform for local businesses with branded stamp cards on Apple and Google Wallets

## Checklist

- [x] Entry is in alphabetical order within the section
- [x] Format matches existing entries