### PR TITLE
Add ARG Software

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Checking the company's Tech stack through [Stackshare](https://stackshare.io/) m
 | [25Friday](https://25friday.com) [:rocket:](https://www.25friday.com/jobs/) | Digital product management focussed on growing tech companies. | `Aveiro` `Porto` |
 | [Accenture](https://www.accenture.com/pt-pt) [:rocket:](https://www.accenture.com/pt-pt/careers) | Software Development, Cyber Security. | `Lisboa` `Porto` <br> `Remote`|
 | [Adentis](https://www.adentis.pt/) [:rocket:](https://www.adentis.pt/en/work-with-us/job-list) | Outsourcing, customized solutions and R&D. | `Lisboa` |
+! [ARG Software](https://arg.software/) [:octocat:](https://github.com/ARG-Software) | Custom software development for SaaS and fintech companies. | `Funchal` `Porto` |
 | [Armis](https://www.armisgroup.com/) [:rocket:](https://www.armisgroup.com/careers) | Technology development and consultancy. | `Lisboa` `Porto` |
 | [Bool Software](https://www.bool.pt/) | Consultancy company specialized in OutSystems. | `Lisboa` |
 | [Caixa Mágica](https://caixamagica.pt/) [:rocket:](https://caixamagica.pt/careers) | Open Source development. | `Lisboa` |

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Checking the company's Tech stack through [Stackshare](https://stackshare.io/) m
 | [25Friday](https://25friday.com) [:rocket:](https://www.25friday.com/jobs/) | Digital product management focussed on growing tech companies. | `Aveiro` `Porto` |
 | [Accenture](https://www.accenture.com/pt-pt) [:rocket:](https://www.accenture.com/pt-pt/careers) | Software Development, Cyber Security. | `Lisboa` `Porto` <br> `Remote`|
 | [Adentis](https://www.adentis.pt/) [:rocket:](https://www.adentis.pt/en/work-with-us/job-list) | Outsourcing, customized solutions and R&D. | `Lisboa` |
-! [ARG Software](https://arg.software/) [:octocat:](https://github.com/ARG-Software) | Custom software development for SaaS and fintech companies. | `Funchal` `Porto` |
+| [ARG Software](https://arg.software/) [:octocat:](https://github.com/ARG-Software) | Custom software development for SaaS and fintech companies. | `Funchal` `Porto` |
 | [Armis](https://www.armisgroup.com/) [:rocket:](https://www.armisgroup.com/careers) | Technology development and consultancy. | `Lisboa` `Porto` |
 | [Bool Software](https://www.bool.pt/) | Consultancy company specialized in OutSystems. | `Lisboa` |
 | [Caixa Mágica](https://caixamagica.pt/) [:rocket:](https://caixamagica.pt/careers) | Open Source development. | `Lisboa` |


### PR DESCRIPTION
Adds ARG Software to the Consultancy / Specialized category.

Company website: https://arg.software
About:https://arg.software/about-us/
Careers: https://arg.software/careers/
GitHub: https://github.com/ARG-Software