### PR TITLE
Add FIZ (FinTech)

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@ Checking the company's Tech stack through [Stackshare](https://stackshare.io/) m
 | [Feedzai](https://feedzai.com) [:rocket:](https://careers.feedzai.com) [:octocat:](https://github.com/feedzai) | Fraud detection platform to make commerce safe. | `Coimbra` `Lisboa` <br> `Porto` `Remote` |
 | [Fidel API](https://fidelapi.com) [:rocket:](https://fidelapi.com/careers/) | One API for linking bank cards to digital applications globally. | `Lisboa` |
 | [Finiam](https://www.finiam.com/) [:rocket:](https://www.finiam.com/#contact) | Improving people's lives by untangling the financial world. | `Braga` `Remote` |
+| [FIZ](https://fiz.co/) [:octocat:](https://github.com/FIZ-co) | Certified invoicing and tax automation for freelancers and SMEs. | `Lisboa` |
 | [Flecto](https://flecto.io/) [:rocket:](https://www.notion.so/flecto/Working-at-Flecto-406db5e14c2c452abe89eecfb015b862) | Rental management for businesses promoting circular economy. | `Lisboa` `Remote` |
 | [Fractal](https://web.fractal.id) | Enabling open finance with a new Internet Identity layer. | `Porto` `Remote` |
 | [Global Blue](https://www.globalblue.com/en) [:rocket:](https://www.globalblue.com/en/about-us/career)| Tax-Free Shopping solutions. | `Lisboa` `Porto` <br> `Remote` |


### PR DESCRIPTION
Adding [FIZ](https://fiz.co/) to the FinTech category.

- **Category:** FinTech (best fit — same space as Rauva/Qonto rows)
- **Website:** https://fiz.co/ (HTTPS, working)
- **Careers page:** none exists, so no :rocket:
- **GitHub:** https://github.com/FIZ-co — public and active (e.g. [fiz-invoicing-skill](https://github.com/FIZ-co/fiz-invoicing-skill))
- **Description:** 64 chars, single line, starts uppercase, ends with a period
- **Location:** `Lisboa` (Cais do Tojo 24, per the website footer)
- Alphabetical order kept: Finiam → FIZ → Flecto

Context: FIZ is an AT-certified invoicing/tax platform (certificate no. 3041 in the [official AT registry](https://www.portaldasfinancas.gov.pt/pt/CD/consultaProgCertificadosM24.action)) for independent workers and small companies in Portugal, HQ'd in Lisboa.

Disclosure: I work with FIZ.